### PR TITLE
feat(organizations): GitHub Classroom integration and org workspace management

### DIFF
--- a/classdock/cli.py
+++ b/classdock/cli.py
@@ -279,6 +279,7 @@ def main(
 from .commands.assignments import assignments_app
 from .commands.automation import automation_app
 from .commands.config import config_app
+from .commands.organizations import organizations_app
 from .commands.repos import repos_app
 from .commands.roster import roster_app
 from .commands.secrets import secrets_app
@@ -290,6 +291,7 @@ app.add_typer(secrets_app, name="secrets")
 app.add_typer(automation_app, name="automation")
 app.add_typer(config_app, name="config")
 app.add_typer(roster_app, name="roster")
+app.add_typer(organizations_app, name="organizations")
 
 
 # ---------------------------------------------------------------------------

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -8,10 +8,12 @@ from rich.table import Table
 
 from ._helpers import get_global_options
 from ..utils import get_logger, setup_logging
+from ..organizations.classroom import ClassroomManager
 from ..organizations.manager import OrganizationManager
 from ..organizations.templates import TemplateManager
 from ..organizations.validators import OrgNameValidator
 from ..services.organization_service import OrganizationService
+from ..utils.github_classroom_api import GitHubClassroomAPIError
 
 logger = get_logger("cli.organizations")
 console = Console()
@@ -316,4 +318,430 @@ def org_verify(
         raise
     except Exception as exc:
         logger.error("Organization verification failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+# ======================================================================
+# Classroom sub-command group
+# ======================================================================
+
+classroom_app = typer.Typer(
+    help="Inspect and replicate GitHub Classroom structure for an organization."
+)
+organizations_app.add_typer(classroom_app, name="classroom")
+
+
+@classroom_app.command("list")
+def classroom_list(
+    ctx: typer.Context,
+    org_login: Optional[str] = typer.Argument(
+        None, help="Filter classrooms by GitHub org login (e.g., SOC-CS3030-Valle-FA26)"
+    ),
+):
+    """
+    List GitHub Classrooms, optionally filtered to a specific organization.
+
+    Examples:
+        $ classdock organizations classroom list
+        $ classdock organizations classroom list SOC-CS3030-Valle-FA26
+    """
+    setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
+    try:
+        mgr = ClassroomManager(token=_get_token())
+        classrooms = (
+            mgr.list_classrooms_for_org(org_login)
+            if org_login
+            else mgr.list_classrooms(enrich_org=True)
+        )
+
+        if not classrooms:
+            msg = f"No classrooms found" + (f" for '{org_login}'" if org_login else "") + "."
+            console.print(f"[yellow]{msg}[/yellow]")
+            return
+
+        title = f"Classrooms for '{org_login}'" if org_login else "Your GitHub Classrooms"
+        table = Table(title=title, show_header=True)
+        table.add_column("ID", style="dim", justify="right")
+        table.add_column("Name", style="cyan")
+        table.add_column("Organization")
+        table.add_column("Archived", justify="center")
+        table.add_column("URL")
+
+        for c in classrooms:
+            table.add_row(
+                str(c.id),
+                c.name,
+                c.org_login or "—",
+                "[yellow]yes[/yellow]" if c.archived else "",
+                c.url or "—",
+            )
+
+        console.print(table)
+
+    except GitHubClassroomAPIError as exc:
+        console.print(f"[red]Classroom API error:[/red] {exc}")
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        logger.error("classroom list failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@classroom_app.command("assignments")
+def classroom_assignments(
+    ctx: typer.Context,
+    org_login: Optional[str] = typer.Argument(
+        None,
+        help="GitHub organization login to filter classrooms (e.g., SOC-CS3030-Valle-FA26). "
+             "If omitted, you will be prompted to select from all accessible classrooms.",
+    ),
+):
+    """
+    Interactively select a classroom and list its assignments.
+
+    When ORG_LOGIN is given, only classrooms linked to that organization are shown.
+    You are then prompted to pick a classroom before the assignment table is displayed.
+
+    Examples:
+        $ classdock organizations classroom assignments
+        $ classdock organizations classroom assignments SOC-CS3030-Valle-FA26
+    """
+    setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
+    try:
+        mgr = ClassroomManager(token=_get_token())
+
+        # Step 1 — build the classroom list (filtered or all)
+        if org_login:
+            classrooms = mgr.list_classrooms_for_org(org_login)
+            scope = f"'{org_login}'"
+        else:
+            classrooms = mgr.list_classrooms(enrich_org=True)
+            scope = "your account"
+
+        if not classrooms:
+            console.print(f"[yellow]No classrooms found for {scope}.[/yellow]")
+            return
+
+        # Step 2 — present a numbered menu for classroom selection
+        console.print(f"\n[bold]Classrooms in {scope}:[/bold]\n")
+        for i, c in enumerate(classrooms, start=1):
+            org_hint = f"  [dim]({c.org_login})[/dim]" if c.org_login else ""
+            archived = "  [yellow][archived][/yellow]" if c.archived else ""
+            console.print(f"  {i}. {c.name}{org_hint}{archived}")
+
+        console.print()
+        choice = typer.prompt(
+            f"Select classroom [1-{len(classrooms)}]",
+            default="1",
+        )
+        try:
+            idx = int(choice) - 1
+            if not 0 <= idx < len(classrooms):
+                raise ValueError
+        except ValueError:
+            console.print("[red]Invalid selection.[/red]")
+            raise typer.Exit(code=1)
+
+        classroom = classrooms[idx]
+
+        # Step 3 — fetch and display assignments
+        assignments = mgr.list_assignments(classroom.id)
+        if not assignments:
+            console.print(f"[yellow]No assignments in classroom '{classroom.name}'.[/yellow]")
+            return
+
+        console.print(f"\n[bold]Assignments in {classroom.name}:[/bold]\n")
+        for i, a in enumerate(assignments, start=1):
+            deadline = f"  [dim]due {a.deadline}[/dim]" if a.deadline else ""
+            console.print(
+                f"  {i}. {a.title}  "
+                f"[dim]{a.type}[/dim]  "
+                f"accepted: {a.accepted_count}{deadline}"
+            )
+
+        console.print()
+        choice = typer.prompt(
+            f"Select assignment to view student repos [1-{len(assignments)}]",
+            default="1",
+        )
+        try:
+            aidx = int(choice) - 1
+            if not 0 <= aidx < len(assignments):
+                raise ValueError
+        except ValueError:
+            console.print("[red]Invalid selection.[/red]")
+            raise typer.Exit(code=1)
+
+        assignment = assignments[aidx]
+
+        # Step 4 — fetch and display student repos for the selected assignment
+        console.print(
+            f"\nFetching student repos for [bold]{assignment.title}[/bold]…\n"
+        )
+        accepted = mgr.get_accepted_assignments(assignment.id)
+
+        if not accepted:
+            console.print(
+                f"[yellow]No student repos found for '{assignment.title}'.[/yellow]"
+            )
+            return
+
+        repo_table = Table(
+            title=f"Student Repos: {assignment.title} ({classroom.name})",
+            show_header=True,
+        )
+        repo_table.add_column("#", style="dim", justify="right")
+        repo_table.add_column("GitHub Username", style="cyan")
+        repo_table.add_column("Repository")
+        repo_table.add_column("Submitted", justify="center")
+        repo_table.add_column("Passing", justify="center")
+        repo_table.add_column("Commits", justify="right")
+        repo_table.add_column("Grade")
+
+        for i, entry in enumerate(accepted, start=1):
+            students = entry.get("students") or []
+            username = students[0].get("login", "—") if students else "—"
+            repo = entry.get("repository") or {}
+            repo_name = repo.get("full_name") or repo.get("name", "—")
+            submitted = "[green]✓[/green]" if entry.get("submitted") else ""
+            passing = "[green]✓[/green]" if entry.get("passing") else ""
+            commits = str(entry.get("commit_count", "—"))
+            grade = str(entry.get("grade", "—")) if entry.get("grade") is not None else "—"
+
+            repo_table.add_row(
+                str(i), username, repo_name, submitted, passing, commits, grade
+            )
+
+        console.print(repo_table)
+        console.print(
+            f"\n[dim]Total: {len(accepted)} student(s) · "
+            f"Assignment ID: {assignment.id}[/dim]"
+        )
+
+    except GitHubClassroomAPIError as exc:
+        console.print(f"[red]Classroom API error:[/red] {exc}")
+        raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        logger.error("classroom assignments failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@classroom_app.command("grades")
+def classroom_grades(
+    ctx: typer.Context,
+    assignment_id: int = typer.Argument(..., help="GitHub Classroom assignment numeric ID"),
+):
+    """
+    Show grading data for an assignment.
+
+    Examples:
+        $ classdock organizations classroom grades 67890
+    """
+    setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
+    try:
+        mgr = ClassroomManager(token=_get_token())
+        assignment = mgr.get_assignment(assignment_id)
+        if assignment is None:
+            console.print(f"[red]Assignment {assignment_id} not found.[/red]")
+            raise typer.Exit(code=1)
+
+        grades = mgr.get_grades(assignment_id)
+        if not grades:
+            console.print(
+                f"[yellow]No grade data for '{assignment.title}' yet.[/yellow]"
+            )
+            return
+
+        table = Table(title=f"Grades: {assignment.title}", show_header=True)
+        table.add_column("GitHub Username", style="cyan")
+        table.add_column("Points Awarded", justify="right")
+        table.add_column("Points Available", justify="right")
+        table.add_column("Submitted At")
+
+        for g in grades:
+            table.add_row(
+                g.get("github_username", "—"),
+                str(g.get("points_awarded", "—")),
+                str(g.get("points_available", "—")),
+                g.get("submission_timestamp", "—") or "—",
+            )
+
+        console.print(table)
+
+    except GitHubClassroomAPIError as exc:
+        console.print(f"[red]Classroom API error:[/red] {exc}")
+        raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        logger.error("classroom grades failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@classroom_app.command("clone")
+def classroom_clone(
+    ctx: typer.Context,
+    source_classroom_id: int = typer.Argument(
+        ..., help="Source GitHub Classroom numeric ID to copy structure from"
+    ),
+    target_org: str = typer.Argument(
+        ..., help="Target GitHub organization login to clone repos and assignments into"
+    ),
+    workspace: Optional[str] = typer.Option(
+        None,
+        "--workspace",
+        help="Local org folder path to write classroom_setup.md (defaults to CWD)",
+    ),
+):
+    """
+    Clone a classroom's assignment structure into a new organization.
+
+    For each assignment in the source classroom:
+      1. Clones its starter-code repo into TARGET_ORG (skips if already exists)
+      2. Generates a direct browser URL to create that assignment in the new classroom
+
+    Since the GitHub Classroom API is read-only, classroom/assignment creation
+    must be completed manually — this command gives you everything you need.
+
+    Examples:
+        $ classdock organizations classroom clone 12345 SOC-CS3030-Valle-FA26
+        $ classdock organizations classroom clone 12345 SOC-CS3030-Valle-FA26 --workspace ~/courses/SOC-CS3030-Valle-FA26
+    """
+    import re as _re
+    from pathlib import Path as _Path
+    from rich.panel import Panel
+
+    setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
+    dry_run = ctx.obj.get("dry_run", False) if ctx.obj else False
+
+    try:
+        token = _get_token()
+        mgr = ClassroomManager(token=token)
+
+        # Fetch source classroom
+        classroom = mgr.get_classroom(source_classroom_id)
+        if classroom is None:
+            console.print(f"[red]Classroom {source_classroom_id} not found.[/red]")
+            raise typer.Exit(code=1)
+
+        assignments = mgr.list_assignments(source_classroom_id)
+        if not assignments:
+            console.print(
+                f"[yellow]No assignments found in classroom '{classroom.name}'.[/yellow]"
+            )
+            return
+
+        console.print(
+            f"\nCloning [cyan]{len(assignments)}[/cyan] assignment(s) from "
+            f"[bold]{classroom.name}[/bold] → [bold]{target_org}[/bold]\n"
+        )
+
+        # Find or prompt for the target classroom ID
+        target_classrooms = mgr.list_classrooms_for_org(target_org)
+        target_classroom_id: Optional[int] = None
+        if target_classrooms:
+            target_classroom_id = target_classrooms[0].id
+            console.print(
+                f"Found classroom [cyan]{target_classrooms[0].name}[/cyan] "
+                f"(ID: {target_classroom_id}) in {target_org}"
+            )
+        else:
+            console.print(
+                f"[yellow]No classroom found for '{target_org}' yet.[/yellow] "
+                f"Create one at: {ClassroomManager.new_classroom_url()}"
+            )
+
+        # Clone starter repos and build checklist
+        tmpl_mgr = TemplateManager(token=token)
+        rows = []
+
+        for a in assignments:
+            starter = a.starter_code_repo  # "owner/repo" or None
+            cloned_status = "—"
+            new_repo = None
+
+            if starter and not dry_run:
+                owner, _, repo_name = starter.partition("/")
+                try:
+                    result = tmpl_mgr.copy_template_repository(
+                        source_owner=owner,
+                        repo_name=repo_name,
+                        target_org=target_org,
+                    )
+                    new_repo = f"{target_org}/{repo_name}"
+                    cloned_status = "[green]✓ cloned[/green]" if result else "[red]✗ failed[/red]"
+                except Exception:
+                    new_repo = f"{target_org}/{repo_name}"
+                    cloned_status = "[yellow]↩ exists[/yellow]"
+            elif dry_run and starter:
+                _, _, repo_name = starter.partition("/")
+                new_repo = f"{target_org}/{repo_name}"
+                cloned_status = "[dim][dry-run][/dim]"
+
+            create_url = (
+                ClassroomManager.assignment_creation_url(
+                    target_classroom_id, new_repo
+                )
+                if target_classroom_id
+                else ClassroomManager.new_classroom_url()
+            )
+            rows.append((a.title, a.type, a.deadline or "—", cloned_status, create_url))
+
+        # Display results table
+        table = Table(
+            title=f"Assignment Checklist: {classroom.name} → {target_org}",
+            show_header=True,
+        )
+        table.add_column("Assignment", style="cyan")
+        table.add_column("Type", justify="center")
+        table.add_column("Deadline")
+        table.add_column("Starter Repo", justify="center")
+        table.add_column("Create URL")
+
+        for title, atype, deadline, status, url in rows:
+            table.add_row(title, atype, deadline, status, url)
+
+        console.print(table)
+
+        # Write classroom_setup.md
+        ws_path = _Path(workspace) if workspace else _Path.cwd()
+        md_path = ws_path / "classroom_setup.md"
+        if not dry_run:
+            lines = [
+                f"# Classroom Setup: {classroom.name} → {target_org}\n\n",
+                "Create the following assignments in your new GitHub Classroom.\n\n",
+                "| Assignment | Type | Deadline | Create URL |\n",
+                "|---|---|---|---|\n",
+            ]
+            for title, atype, deadline, _, url in rows:
+                lines.append(f"| {title} | {atype} | {deadline} | {url} |\n")
+            md_path.write_text("".join(lines), encoding="utf-8")
+            console.print(
+                f"\n[dim]Checklist written to:[/dim] {md_path}"
+            )
+
+        console.print(
+            Panel(
+                f"[bold]Next steps:[/bold]\n\n"
+                + (
+                    f"  1. A classroom already exists for {target_org} — use the Create URLs above.\n"
+                    if target_classroom_id
+                    else f"  1. Create a classroom for [cyan]{target_org}[/cyan]:\n"
+                    f"     {ClassroomManager.new_classroom_url()}\n"
+                    f"  2. Then use the Create URLs above to add each assignment.\n"
+                )
+                + (f"\n  Checklist saved to: {md_path}" if not dry_run else ""),
+                title="GitHub Classroom",
+                border_style="blue",
+            )
+        )
+
+    except GitHubClassroomAPIError as exc:
+        console.print(f"[red]Classroom API error:[/red] {exc}")
+        raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        logger.error("classroom clone failed: %s", exc)
         raise typer.Exit(code=1)

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -1,0 +1,283 @@
+"""Organizations command group for ClassDock."""
+
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ._helpers import get_global_options
+from ..utils import get_logger, setup_logging
+from ..organizations.manager import OrganizationManager
+from ..organizations.validators import OrgNameValidator
+from ..services.organization_service import OrganizationService
+
+logger = get_logger("cli.organizations")
+console = Console()
+
+
+def _get_token() -> Optional[str]:
+    """Load the GitHub token from classdock's token store (same priority as other commands)."""
+    try:
+        from ..utils.token_manager import GitHubTokenManager
+        return GitHubTokenManager().get_github_token()
+    except Exception:
+        return None
+
+organizations_app = typer.Typer(
+    help="GitHub organization lifecycle management: create, list, and clone templates."
+)
+
+
+@organizations_app.callback()
+def organizations_callback(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose output"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be done without executing"
+    ),
+):
+    """GitHub organization lifecycle management."""
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose or ctx.obj.get("verbose", False)
+    ctx.obj["dry_run"] = dry_run or ctx.obj.get("dry_run", False)
+
+
+@organizations_app.command("init")
+def org_init(ctx: typer.Context):
+    """
+    Launch the interactive wizard to set up a new GitHub organization and workspace.
+
+    The wizard will:
+    \\b
+      1. Verify your GitHub token scopes
+      2. Detect or prompt for your master template folder
+      3. Let you select which template repos to carry forward
+      4. Build and validate the new organization name
+      5. Create a local semester org folder
+      6. Clone selected templates locally
+      7. Create the GitHub organization
+      8. Fork templates into the new org (marking them as GitHub templates)
+      9. Guide you through GitHub Classroom setup
+
+    Examples:
+        $ classdock organizations init
+        $ classdock organizations init --dry-run
+    """
+    verbose, dry_run = get_global_options(ctx)
+    setup_logging(verbose)
+
+    try:
+        service = OrganizationService(token=_get_token(), dry_run=dry_run, verbose=verbose)
+        ok, message = service.setup()
+
+        if ok:
+            console.print(f"[green]✓ {message}[/green]")
+        else:
+            console.print(f"[red]✗ {message}[/red]")
+            raise typer.Exit(code=1)
+
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        logger.error("Organization init failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@organizations_app.command("create")
+def org_create(
+    ctx: typer.Context,
+    login: str = typer.Option(..., "--login", help="Organization login (e.g., SOC-CS3030-Valle-SU26)"),
+    email: str = typer.Option(..., "--email", help="Billing contact email"),
+    name: Optional[str] = typer.Option(None, "--name", help="Organization display name"),
+):
+    """
+    Create a new GitHub organization (non-interactive).
+
+    Requires the ``admin:org`` scope on your GitHub token.
+
+    Examples:
+        $ classdock organizations create --login SOC-CS3030-Valle-SU26 --email me@weber.edu
+        $ classdock organizations create --login SOC-CS3030-Valle-SU26 --email me@weber.edu --name "CS3030 SU26"
+    """
+    verbose, dry_run = get_global_options(ctx)
+    setup_logging(verbose)
+
+    result = OrgNameValidator.validate(login)
+    if not result.is_valid:
+        console.print(f"[red]Invalid organization name:[/red]\n{result.error}")
+        raise typer.Exit(code=1)
+
+    if dry_run:
+        console.print(f"[dim][dry-run] Would create GitHub org: {login}[/dim]")
+        return
+
+    try:
+        mgr = OrganizationManager(token=_get_token())
+        org = mgr.create_organization(login=login, billing_email=email, display_name=name)
+        console.print(f"[green]✓ Organization '{org.login}' created.[/green]")
+        if org.url:
+            console.print(f"  URL: {org.url}")
+    except PermissionError as exc:
+        console.print(f"[red]Permission error:[/red]\n{exc}")
+        raise typer.Exit(code=1)
+    except NotImplementedError as exc:
+        console.print(f"[yellow]{exc}[/yellow]")
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        logger.error("Organization creation failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@organizations_app.command("list")
+def org_list(ctx: typer.Context):
+    """
+    List GitHub organizations the authenticated user belongs to.
+
+    Examples:
+        $ classdock organizations list
+    """
+    verbose, _ = get_global_options(ctx)
+    setup_logging(verbose)
+
+    try:
+        mgr = OrganizationManager(token=_get_token())
+        orgs = mgr.list_user_organizations()
+
+        if not orgs:
+            console.print("[yellow]No organizations found.[/yellow]")
+            return
+
+        table = Table(title="Your GitHub Organizations", show_header=True)
+        table.add_column("Login", style="cyan")
+        table.add_column("Name")
+        table.add_column("Role")
+
+        for org in orgs:
+            table.add_row(
+                org.login,
+                org.name or "",
+                org.role or "",
+            )
+
+        console.print(table)
+
+    except Exception as exc:
+        logger.error("Failed to list organizations: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@organizations_app.command("clone-templates")
+def org_clone_templates(
+    ctx: typer.Context,
+    source_org: str = typer.Option(..., "--source-org", help="Organization to clone templates from"),
+    target_org: str = typer.Option(..., "--target-org", help="Organization to clone templates into"),
+    repos: Optional[List[str]] = typer.Option(
+        None,
+        "--repos",
+        help="Repo names to clone (repeat for multiple). Omit to clone all templates.",
+    ),
+):
+    """
+    Fork template repositories from one organization to another.
+
+    Each forked repository is automatically marked as a GitHub template.
+    If --repos is omitted, all template repos in the source org are cloned.
+
+    Examples:
+        $ classdock organizations clone-templates \\
+              --source-org CS3030 \\
+              --target-org SOC-CS3030-Valle-SU26
+
+        $ classdock organizations clone-templates \\
+              --source-org CS3030 \\
+              --target-org SOC-CS3030-Valle-SU26 \\
+              --repos python-basics \\
+              --repos midterm-project
+    """
+    verbose, dry_run = get_global_options(ctx)
+    setup_logging(verbose)
+
+    try:
+        service = OrganizationService(token=_get_token(), dry_run=dry_run, verbose=verbose)
+        result = service.clone_templates(
+            source_org=source_org,
+            target_org=target_org,
+            repo_names=list(repos) if repos else [],
+        )
+
+        if result.total == 0:
+            console.print("[yellow]No repositories to clone.[/yellow]")
+            return
+
+        console.print(
+            f"\n[bold]Clone Results:[/bold] "
+            f"[green]{result.successful}[/green]/{result.total} succeeded"
+        )
+        if result.errors:
+            console.print("[red]Errors:[/red]")
+            for err in result.errors:
+                console.print(f"  • {err}")
+
+        if result.failed > 0:
+            raise typer.Exit(code=1)
+
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        logger.error("clone-templates failed: %s", exc)
+        raise typer.Exit(code=1)
+
+
+@organizations_app.command("verify")
+def org_verify(
+    ctx: typer.Context,
+    login: str = typer.Argument(..., help="Organization login to verify"),
+):
+    """
+    Verify that a GitHub organization exists and show its details.
+
+    Examples:
+        $ classdock organizations verify SOC-CS3030-Valle-SU26
+    """
+    verbose, _ = get_global_options(ctx)
+    setup_logging(verbose)
+
+    try:
+        # Validate name format
+        val = OrgNameValidator.validate(login)
+        if not val.is_valid:
+            console.print(
+                f"[yellow]Warning: '{login}' does not match the ClassDock naming convention.[/yellow]"
+            )
+
+        mgr = OrganizationManager(token=_get_token())  # noqa: F811
+        org = mgr.get_organization(login)
+
+        if org is None:
+            console.print(f"[red]Organization '{login}' not found on GitHub.[/red]")
+            raise typer.Exit(code=1)
+
+        table = Table(title=f"Organization: {org.login}")
+        table.add_column("Field", style="cyan")
+        table.add_column("Value")
+        table.add_row("Login", org.login)
+        table.add_row("Name", org.name or "—")
+        table.add_row("URL", org.url or "—")
+        table.add_row("Role", org.role or "—")
+
+        if val.is_valid:
+            table.add_row("Semester", val.semester_label or "—")
+            table.add_row("Year", val.full_year or "—")
+            table.add_row("Instructor", val.lastname or "—")
+
+        console.print(table)
+        console.print("[green]✓ Organization verified.[/green]")
+
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        logger.error("Organization verification failed: %s", exc)
+        raise typer.Exit(code=1)

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -9,6 +9,7 @@ from rich.table import Table
 from ._helpers import get_global_options
 from ..utils import get_logger, setup_logging
 from ..organizations.manager import OrganizationManager
+from ..organizations.templates import TemplateManager
 from ..organizations.validators import OrgNameValidator
 from ..services.organization_service import OrganizationService
 
@@ -253,12 +254,18 @@ def org_verify(
                 f"[yellow]Warning: '{login}' does not match the ClassDock naming convention.[/yellow]"
             )
 
-        mgr = OrganizationManager(token=_get_token())  # noqa: F811
+        token = _get_token()
+        mgr = OrganizationManager(token=token)
         org = mgr.get_organization(login)
 
         if org is None:
             console.print(f"[red]Organization '{login}' not found on GitHub.[/red]")
             raise typer.Exit(code=1)
+
+        # Fetch repo counts
+        tmpl_mgr = TemplateManager(token=token)
+        all_repos = tmpl_mgr.list_org_repos(login, templates_only=False)
+        template_repos = [r for r in all_repos if r.is_template]
 
         table = Table(title=f"Organization: {org.login}")
         table.add_column("Field", style="cyan")
@@ -267,6 +274,8 @@ def org_verify(
         table.add_row("Name", org.name or "—")
         table.add_row("URL", org.url or "—")
         table.add_row("Role", org.role or "—")
+        table.add_row("Repositories", str(len(all_repos)))
+        table.add_row("Template repos", str(len(template_repos)))
 
         if val.is_valid:
             table.add_row("Semester", val.semester_label or "—")
@@ -274,6 +283,15 @@ def org_verify(
             table.add_row("Instructor", val.lastname or "—")
 
         console.print(table)
+
+        if all_repos:
+            repo_table = Table(title="Repositories", show_header=True)
+            repo_table.add_column("Name", style="cyan")
+            repo_table.add_column("Template", justify="center")
+            for repo in all_repos:
+                repo_table.add_row(repo.name, "[green]✓[/green]" if repo.is_template else "")
+            console.print(repo_table)
+
         console.print("[green]✓ Organization verified.[/green]")
 
     except typer.Exit:

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -213,14 +213,32 @@ def org_clone_templates(
             console.print("[yellow]No repositories to clone.[/yellow]")
             return
 
-        console.print(
-            f"\n[bold]Clone Results:[/bold] "
-            f"[green]{result.successful}[/green]/{result.total} succeeded"
-        )
-        if result.errors:
-            console.print("[red]Errors:[/red]")
-            for err in result.errors:
-                console.print(f"  • {err}")
+        # Build per-repo status table
+        cloned_names = {r.name for r in result.cloned_repos}
+        existed_names = set(result.already_existed)
+
+        table = Table(title=f"Clone: {source_org} → {target_org}", show_header=True)
+        table.add_column("Repository", style="cyan")
+        table.add_column("Status", justify="center")
+
+        for repo_name in result.attempted_names:
+            if repo_name in cloned_names:
+                table.add_row(repo_name, "[green]✓ cloned[/green]")
+            elif repo_name in existed_names:
+                table.add_row(repo_name, "[yellow]↩ exists[/yellow]")
+            else:
+                table.add_row(repo_name, "[red]✗ failed[/red]")
+
+        console.print(table)
+
+        parts = []
+        if result.successful:
+            parts.append(f"[green]{result.successful} cloned[/green]")
+        if result.already_existed:
+            parts.append(f"[yellow]{len(result.already_existed)} already existed[/yellow]")
+        if result.failed:
+            parts.append(f"[red]{result.failed} failed[/red]")
+        console.print("\nSummary: " + " · ".join(parts))
 
         if result.failed > 0:
             raise typer.Exit(code=1)

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -780,6 +780,7 @@ def classroom_clone(
 
         # Write classroom_setup.md
         ws_path = _Path(workspace) if workspace else _Path.cwd()
+        ws_path.mkdir(parents=True, exist_ok=True)
         md_path = ws_path / "classroom_setup.md"
         if not dry_run:
             lines = [

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -530,37 +530,108 @@ def classroom_assignments(
 @classroom_app.command("grades")
 def classroom_grades(
     ctx: typer.Context,
-    assignment_id: int = typer.Argument(..., help="GitHub Classroom assignment numeric ID"),
+    org_login: Optional[str] = typer.Argument(
+        None,
+        help="GitHub organization login to filter classrooms. "
+             "If omitted, all accessible classrooms are shown.",
+    ),
 ):
     """
-    Show grading data for an assignment.
+    Interactively select a classroom and assignment, then show grade data.
+
+    Three-level drill-down:
+      1. Select organization → classroom list
+      2. Select classroom → assignment list
+      3. Select assignment → grades table
 
     Examples:
-        $ classdock organizations classroom grades 67890
+        $ classdock organizations classroom grades
+        $ classdock organizations classroom grades SOC-CS3030-Valle-FA26
     """
     setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
     try:
         mgr = ClassroomManager(token=_get_token())
-        assignment = mgr.get_assignment(assignment_id)
-        if assignment is None:
-            console.print(f"[red]Assignment {assignment_id} not found.[/red]")
+
+        # Step 1 — classroom list
+        if org_login:
+            classrooms = mgr.list_classrooms_for_org(org_login)
+            scope = f"'{org_login}'"
+        else:
+            classrooms = mgr.list_classrooms(enrich_org=True)
+            scope = "your account"
+
+        if not classrooms:
+            console.print(f"[yellow]No classrooms found for {scope}.[/yellow]")
+            return
+
+        console.print(f"\n[bold]Classrooms in {scope}:[/bold]\n")
+        for i, c in enumerate(classrooms, start=1):
+            org_hint = f"  [dim]({c.org_login})[/dim]" if c.org_login else ""
+            archived = "  [yellow][archived][/yellow]" if c.archived else ""
+            console.print(f"  {i}. {c.name}{org_hint}{archived}")
+
+        console.print()
+        choice = typer.prompt(f"Select classroom [1-{len(classrooms)}]", default="1")
+        try:
+            idx = int(choice) - 1
+            if not 0 <= idx < len(classrooms):
+                raise ValueError
+        except ValueError:
+            console.print("[red]Invalid selection.[/red]")
             raise typer.Exit(code=1)
 
-        grades = mgr.get_grades(assignment_id)
+        classroom = classrooms[idx]
+
+        # Step 2 — assignment list
+        assignments = mgr.list_assignments(classroom.id)
+        if not assignments:
+            console.print(f"[yellow]No assignments in classroom '{classroom.name}'.[/yellow]")
+            return
+
+        console.print(f"\n[bold]Assignments in {classroom.name}:[/bold]\n")
+        for i, a in enumerate(assignments, start=1):
+            deadline = f"  [dim]due {a.deadline}[/dim]" if a.deadline else ""
+            console.print(
+                f"  {i}. {a.title}  "
+                f"[dim]{a.type}[/dim]  "
+                f"accepted: {a.accepted_count}{deadline}"
+            )
+
+        console.print()
+        choice = typer.prompt(
+            f"Select assignment [1-{len(assignments)}]", default="1"
+        )
+        try:
+            aidx = int(choice) - 1
+            if not 0 <= aidx < len(assignments):
+                raise ValueError
+        except ValueError:
+            console.print("[red]Invalid selection.[/red]")
+            raise typer.Exit(code=1)
+
+        assignment = assignments[aidx]
+
+        # Step 3 — grades table
+        grades = mgr.get_grades(assignment.id)
         if not grades:
             console.print(
                 f"[yellow]No grade data for '{assignment.title}' yet.[/yellow]"
             )
             return
 
-        table = Table(title=f"Grades: {assignment.title}", show_header=True)
+        table = Table(
+            title=f"Grades: {assignment.title} ({classroom.name})",
+            show_header=True,
+        )
+        table.add_column("#", style="dim", justify="right")
         table.add_column("GitHub Username", style="cyan")
         table.add_column("Points Awarded", justify="right")
         table.add_column("Points Available", justify="right")
         table.add_column("Submitted At")
 
-        for g in grades:
+        for i, g in enumerate(grades, start=1):
             table.add_row(
+                str(i),
                 g.get("github_username", "—"),
                 str(g.get("points_awarded", "—")),
                 str(g.get("points_available", "—")),
@@ -568,6 +639,9 @@ def classroom_grades(
             )
 
         console.print(table)
+        console.print(
+            f"\n[dim]Total: {len(grades)} student(s) · Assignment ID: {assignment.id}[/dim]"
+        )
 
     except GitHubClassroomAPIError as exc:
         console.print(f"[red]Classroom API error:[/red] {exc}")

--- a/classdock/organizations/__init__.py
+++ b/classdock/organizations/__init__.py
@@ -1,0 +1,29 @@
+"""
+Organizations module for ClassDock.
+
+Provides GitHub organization lifecycle management including:
+- Organization creation and listing
+- Template repository cloning between organizations
+- Local workspace folder management (master folder + semester org folder)
+- Interactive setup wizard
+- Naming convention validation
+"""
+
+from .models import (
+    CloneResult,
+    Organization,
+    SetupResult,
+    TemplateRepo,
+    WorkspaceFolder,
+)
+from .validators import OrgNameValidator, ValidationResult
+
+__all__ = [
+    "Organization",
+    "TemplateRepo",
+    "WorkspaceFolder",
+    "CloneResult",
+    "SetupResult",
+    "OrgNameValidator",
+    "ValidationResult",
+]

--- a/classdock/organizations/__init__.py
+++ b/classdock/organizations/__init__.py
@@ -7,9 +7,13 @@ Provides GitHub organization lifecycle management including:
 - Local workspace folder management (master folder + semester org folder)
 - Interactive setup wizard
 - Naming convention validation
+- GitHub Classroom integration (list, inspect, clone classroom structure)
 """
 
+from .classroom import ClassroomManager
 from .models import (
+    Classroom,
+    ClassroomAssignment,
     CloneResult,
     Organization,
     SetupResult,
@@ -26,4 +30,7 @@ __all__ = [
     "SetupResult",
     "OrgNameValidator",
     "ValidationResult",
+    "Classroom",
+    "ClassroomAssignment",
+    "ClassroomManager",
 ]

--- a/classdock/organizations/classroom.py
+++ b/classdock/organizations/classroom.py
@@ -1,0 +1,204 @@
+"""
+GitHub Classroom integration for organization management.
+
+Provides ClassroomManager which wraps the GitHub Classroom REST API to:
+- List classrooms linked to a GitHub organization
+- List assignments within a classroom
+- Retrieve grade and accepted-assignment data
+- Generate deep-link URLs for one-click assignment creation in the web UI
+- Clone a classroom's starter repo set into a target org
+"""
+
+import logging
+from typing import List, Optional
+
+from ..utils.github_classroom_api import GitHubClassroomAPI, GitHubClassroomAPIError
+from .models import Classroom, ClassroomAssignment
+
+logger = logging.getLogger(__name__)
+
+_CLASSROOM_NEW_URL = "https://classroom.github.com/classrooms/{classroom_id}/assignments/new"
+
+
+class ClassroomManager:
+    """
+    Manages GitHub Classroom data for a given token holder.
+
+    Wraps GitHubClassroomAPI with typed models, pagination, and org-scoped
+    filtering.  All write operations (create classroom, create assignment) must
+    be performed via the GitHub Classroom web UI — the REST API is read-only.
+
+    Args:
+        token: GitHub personal access token.
+    """
+
+    def __init__(self, token: Optional[str] = None):
+        if not token:
+            raise ValueError("GitHub token is required for Classroom API access.")
+        self._api = GitHubClassroomAPI(github_token=token)
+
+    # ------------------------------------------------------------------
+    # Classroom discovery
+    # ------------------------------------------------------------------
+
+    def list_classrooms(self, enrich_org: bool = False) -> List[Classroom]:
+        """
+        Return all classrooms accessible to the authenticated user.
+
+        Args:
+            enrich_org: If True, fetch full classroom details for each entry
+                        to populate org_login (extra N API calls).  Use only
+                        when the org column is needed in display output.
+
+        Returns:
+            Sorted list of Classroom objects (alphabetically by name).
+        """
+        raw = self._api.get_classrooms_paginated()
+        classrooms = [Classroom.from_dict(c) for c in raw]
+        if enrich_org:
+            enriched = []
+            for c in classrooms:
+                if not c.org_login:
+                    full = self.get_classroom(c.id)
+                    enriched.append(full if full else c)
+                else:
+                    enriched.append(c)
+            classrooms = enriched
+        classrooms.sort(key=lambda c: c.name.lower())
+        logger.debug("Found %d accessible classrooms", len(classrooms))
+        return classrooms
+
+    def list_classrooms_for_org(self, org_login: str) -> List[Classroom]:
+        """
+        Return classrooms linked to a specific GitHub organization.
+
+        The GitHub Classroom list endpoint does not include organization details,
+        so this method fetches full details for each classroom to resolve the
+        org login.  Most instructors have few classrooms, so N+1 calls are
+        acceptable here.
+
+        Args:
+            org_login: GitHub organization login to filter by.
+
+        Returns:
+            List of Classroom objects linked to that org.
+        """
+        all_classrooms = self.list_classrooms()
+        matched = []
+        for c in all_classrooms:
+            # Enrich with full details if org_login not already populated
+            if not c.org_login:
+                full = self.get_classroom(c.id)
+                if full:
+                    c = full
+            if c.org_login.lower() == org_login.lower():
+                matched.append(c)
+        return matched
+
+    def get_classroom(self, classroom_id: int) -> Optional[Classroom]:
+        """
+        Return a single classroom by ID, or None if not found / not accessible.
+
+        Args:
+            classroom_id: GitHub Classroom numeric ID.
+        """
+        try:
+            raw = self._api.get_classroom(classroom_id)
+            return Classroom.from_dict(raw)
+        except GitHubClassroomAPIError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+
+    # ------------------------------------------------------------------
+    # Assignment operations
+    # ------------------------------------------------------------------
+
+    def list_assignments(self, classroom_id: int) -> List[ClassroomAssignment]:
+        """
+        Return all assignments for a classroom.
+
+        Args:
+            classroom_id: GitHub Classroom numeric ID.
+
+        Returns:
+            List of ClassroomAssignment objects.
+        """
+        raw = self._api.get_classroom_assignments_paginated(classroom_id)
+        assignments = [ClassroomAssignment.from_dict(a) for a in raw]
+        logger.debug(
+            "Found %d assignments in classroom %d", len(assignments), classroom_id
+        )
+        return assignments
+
+    def get_assignment(self, assignment_id: int) -> Optional[ClassroomAssignment]:
+        """
+        Return a single assignment by ID, or None if not found.
+
+        Args:
+            assignment_id: GitHub Classroom assignment numeric ID.
+        """
+        try:
+            raw = self._api.get_assignment(assignment_id)
+            return ClassroomAssignment.from_dict(raw)
+        except GitHubClassroomAPIError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+
+    def get_accepted_assignments(self, assignment_id: int) -> List[dict]:
+        """
+        Return all student-accepted repositories for an assignment.
+
+        Args:
+            assignment_id: GitHub Classroom assignment numeric ID.
+
+        Returns:
+            List of raw accepted-assignment dicts from the API.
+        """
+        return self._api.get_accepted_assignments_paginated(assignment_id)
+
+    def get_grades(self, assignment_id: int) -> List[dict]:
+        """
+        Return grading records for an assignment.
+
+        Args:
+            assignment_id: GitHub Classroom assignment numeric ID.
+
+        Returns:
+            List of grade record dicts from the API.
+        """
+        return self._api.get_assignment_grades(assignment_id)
+
+    # ------------------------------------------------------------------
+    # Deep-link URL helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def assignment_creation_url(
+        classroom_id: int,
+        template_repo: Optional[str] = None,
+    ) -> str:
+        """
+        Return the GitHub Classroom URL to pre-fill a new assignment.
+
+        Since the Classroom API has no create endpoint, instructors must use
+        the web UI.  This URL deep-links directly to the new-assignment form
+        with the template repo pre-selected (when provided).
+
+        Args:
+            classroom_id: GitHub Classroom numeric ID.
+            template_repo: "owner/repo" of the starter code template (optional).
+
+        Returns:
+            URL string the instructor can open in a browser.
+        """
+        base = _CLASSROOM_NEW_URL.format(classroom_id=classroom_id)
+        if template_repo:
+            return f"{base}?template_repo={template_repo}"
+        return base
+
+    @staticmethod
+    def new_classroom_url() -> str:
+        """Return the URL to create a new GitHub Classroom."""
+        return "https://classroom.github.com/classrooms/new"

--- a/classdock/organizations/manager.py
+++ b/classdock/organizations/manager.py
@@ -1,0 +1,170 @@
+"""
+GitHub Organization Manager.
+
+Handles CRUD operations for GitHub organizations:
+- Listing organizations the user belongs to
+- Checking whether an organization exists
+- Creating organizations (via GraphQL)
+- Fetching organization details
+
+All REST operations reuse the shared GitHubAPIClient.
+Organization creation uses the GitHubGraphQLClient because the
+REST API does not expose an endpoint for creating organizations.
+"""
+
+import logging
+from typing import List, Optional
+
+from ..utils.github_api_client import GitHubAPIClient
+from ..utils.github_graphql_client import GitHubGraphQLClient
+from .models import Organization
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationManager:
+    """
+    Manages GitHub organization lifecycle operations.
+
+    Args:
+        token: GitHub personal access token. Falls back to GITHUB_TOKEN env var.
+    """
+
+    def __init__(self, token: Optional[str] = None):
+        self._rest = GitHubAPIClient(token=token)
+        self._graphql = GitHubGraphQLClient(token=token)
+
+    # ------------------------------------------------------------------
+    # Listing and discovery
+    # ------------------------------------------------------------------
+
+    def list_user_organizations(self) -> List[Organization]:
+        """
+        Return all GitHub organizations the authenticated user belongs to.
+
+        Returns:
+            List of Organization objects, sorted by login.
+        """
+        raw = self._rest.list_user_organizations()
+        orgs = [Organization.from_dict(d) for d in raw]
+        orgs.sort(key=lambda o: o.login.lower())
+        logger.debug("Found %d user organizations", len(orgs))
+        return orgs
+
+    def get_organization(self, login: str) -> Optional[Organization]:
+        """
+        Fetch a single organization by login.
+
+        Args:
+            login: Organization login (slug).
+
+        Returns:
+            Organization if found, None otherwise.
+        """
+        raw = self._rest.get_organization(login)
+        if raw is None:
+            return None
+        return Organization.from_dict(raw)
+
+    def organization_exists(self, login: str) -> bool:
+        """
+        Check whether an organization with the given login exists on GitHub.
+
+        Args:
+            login: Organization login to check.
+
+        Returns:
+            True if the organization exists, False otherwise.
+        """
+        return self._rest.organization_exists(login)
+
+    # ------------------------------------------------------------------
+    # Creation
+    # ------------------------------------------------------------------
+
+    def create_organization(
+        self,
+        login: str,
+        billing_email: str,
+        display_name: Optional[str] = None,
+    ) -> Organization:
+        """
+        Create a new GitHub organization via the GraphQL API.
+
+        This requires the ``admin:org`` OAuth scope on the token.
+        If the scope is missing, an informative error is raised before
+        making the API call.
+
+        Args:
+            login: The organization slug (e.g., SOC-CS3030-Valle-SU26).
+            billing_email: Billing contact email for the new organization.
+            display_name: Human-readable name for the organization.
+                          Falls back to login if not provided.
+
+        Returns:
+            Organization object representing the newly created org.
+
+        Raises:
+            PermissionError: If the token lacks the ``admin:org`` scope.
+            RuntimeError: If the organization creation fails for other reasons.
+        """
+        # Pre-flight: verify required token scope
+        if not self._graphql.has_scope("admin:org"):
+            scopes = self._graphql.get_token_scopes()
+            raise PermissionError(
+                f"GitHub token is missing the 'admin:org' scope.\n"
+                f"Current scopes: {', '.join(scopes) or 'none'}\n\n"
+                f"To fix:\n"
+                f"  1. Visit https://github.com/settings/tokens\n"
+                f"  2. Select your ClassDock token\n"
+                f"  3. Enable the 'admin:org' scope\n"
+                f"  4. Re-save the token with: classdock config token <NEW_TOKEN>"
+            )
+
+        logger.info("Creating GitHub organization '%s'", login)
+        try:
+            org_data = self._graphql.create_organization(
+                login=login,
+                billing_email=billing_email,
+            )
+        except Exception as exc:
+            msg = str(exc)
+            # GitHub's GraphQL `createOrganization` mutation is only available on
+            # GitHub Enterprise Cloud/Server — not on github.com personal/pro accounts.
+            if "doesn't exist on type 'Mutation'" in msg or "createOrganization" in msg:
+                raise NotImplementedError(
+                    "GitHub does not support programmatic organization creation via API "
+                    "for non-Enterprise accounts.\n\n"
+                    "Please create the organization manually:\n"
+                    f"  1. Go to https://github.com/organizations/plan\n"
+                    f"  2. Choose a free plan\n"
+                    f"  3. Set the organization name to: {login}\n"
+                    f"  4. Re-run this command or use: classdock organizations clone-templates"
+                ) from exc
+            raise
+
+        org = Organization(
+            login=org_data.get("login", login),
+            name=display_name or org_data.get("name") or login,
+            url=org_data.get("url"),
+        )
+        logger.info("Organization '%s' created: %s", login, org.url)
+        return org
+
+    # ------------------------------------------------------------------
+    # Token scope helpers (exposed for the wizard)
+    # ------------------------------------------------------------------
+
+    def get_token_scopes(self) -> List[str]:
+        """Return the OAuth scopes of the current token."""
+        return self._graphql.get_token_scopes()
+
+    def has_required_scopes(self) -> bool:
+        """
+        Check that the token has all scopes required for the full wizard.
+
+        Required scopes: repo, read:org, admin:org
+        """
+        scopes = set(self.get_token_scopes())
+        required = {"repo", "admin:org"}
+        return required.issubset(scopes)

--- a/classdock/organizations/models.py
+++ b/classdock/organizations/models.py
@@ -181,6 +181,8 @@ class CloneResult:
     failed: int = 0
     cloned_repos: List[TemplateRepo] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
+    already_existed: List[str] = field(default_factory=list)
+    attempted_names: List[str] = field(default_factory=list)
 
     def add_success(self, repo: TemplateRepo) -> None:
         """Record a successful clone."""
@@ -191,6 +193,10 @@ class CloneResult:
         """Record a clone failure."""
         self.errors.append(error)
         self.failed += 1
+
+    def add_already_existed(self, repo_name: str) -> None:
+        """Record a repo that was skipped because it already exists in the target org."""
+        self.already_existed.append(repo_name)
 
     @property
     def success_rate(self) -> float:

--- a/classdock/organizations/models.py
+++ b/classdock/organizations/models.py
@@ -2,12 +2,12 @@
 Data models for ClassDock organization management.
 
 Defines dataclasses for GitHub organizations, template repositories,
-local workspace folders, and operation results.
+local workspace folders, operation results, and GitHub Classroom data.
 """
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -224,3 +224,107 @@ class SetupResult:
     clone_result: Optional[CloneResult] = None
     success: bool = False
     error_message: Optional[str] = None
+
+
+@dataclass
+class Classroom:
+    """
+    Represents a GitHub Classroom.
+
+    Attributes:
+        id: GitHub Classroom numeric ID
+        name: Classroom display name
+        url: URL to the classroom on classroom.github.com
+        archived: Whether the classroom is archived
+        org_login: Login of the GitHub organization linked to this classroom
+    """
+
+    id: int
+    name: str
+    url: str = ""
+    archived: bool = False
+    org_login: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Classroom":
+        """Create a Classroom from a GitHub Classroom API response dict."""
+        org = data.get("organization") or {}
+        return cls(
+            id=data["id"],
+            name=data.get("name", ""),
+            url=data.get("url", ""),
+            archived=data.get("archived", False),
+            org_login=org.get("login", "") if isinstance(org, dict) else "",
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "url": self.url,
+            "archived": self.archived,
+            "org_login": self.org_login,
+        }
+
+
+@dataclass
+class ClassroomAssignment:
+    """
+    Represents an assignment within a GitHub Classroom.
+
+    Attributes:
+        id: GitHub Classroom assignment numeric ID
+        title: Assignment title
+        type: Assignment type — "individual" or "group"
+        deadline: ISO-8601 deadline string, or None
+        accepted_count: Number of students who accepted
+        submitted_count: Number of students who submitted
+        passing_count: Number of submissions passing autograding
+        starter_code_repo: "owner/repo" of the starter code template, or None
+        invite_link: GitHub Classroom invite URL for students
+        classroom_id: ID of the parent classroom
+    """
+
+    id: int
+    title: str
+    type: str = "individual"
+    deadline: Optional[str] = None
+    accepted_count: int = 0
+    submitted_count: int = 0
+    passing_count: int = 0
+    starter_code_repo: Optional[str] = None
+    invite_link: Optional[str] = None
+    classroom_id: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ClassroomAssignment":
+        """Create a ClassroomAssignment from a GitHub Classroom API response dict."""
+        starter = data.get("starter_code_repository") or {}
+        starter_repo = starter.get("full_name") if isinstance(starter, dict) else None
+        classroom = data.get("classroom") or {}
+        return cls(
+            id=data["id"],
+            title=data.get("title", ""),
+            type=data.get("type", "individual"),
+            deadline=data.get("deadline"),
+            accepted_count=data.get("accepted", 0),
+            submitted_count=data.get("submitted", 0),
+            passing_count=data.get("passing", 0),
+            starter_code_repo=starter_repo,
+            invite_link=data.get("invite_link"),
+            classroom_id=classroom.get("id", 0) if isinstance(classroom, dict) else 0,
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "type": self.type,
+            "deadline": self.deadline,
+            "accepted_count": self.accepted_count,
+            "submitted_count": self.submitted_count,
+            "passing_count": self.passing_count,
+            "starter_code_repo": self.starter_code_repo,
+            "invite_link": self.invite_link,
+            "classroom_id": self.classroom_id,
+        }

--- a/classdock/organizations/models.py
+++ b/classdock/organizations/models.py
@@ -1,0 +1,220 @@
+"""
+Data models for ClassDock organization management.
+
+Defines dataclasses for GitHub organizations, template repositories,
+local workspace folders, and operation results.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class Organization:
+    """
+    Represents a GitHub organization.
+
+    Attributes:
+        login: Organization login (slug used in URLs)
+        name: Organization display name
+        id: GitHub organization ID
+        description: Organization description
+        url: HTML URL to organization on GitHub
+        avatar_url: Organization avatar URL
+        role: Authenticated user's role in the org (admin, member)
+    """
+
+    login: str
+    name: Optional[str] = None
+    id: Optional[int] = None
+    description: Optional[str] = None
+    url: Optional[str] = None
+    avatar_url: Optional[str] = None
+    role: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Organization":
+        """Create Organization from a GitHub API response dict."""
+        return cls(
+            login=data.get("login", ""),
+            name=data.get("name"),
+            id=data.get("id"),
+            description=data.get("description"),
+            url=data.get("html_url"),
+            avatar_url=data.get("avatar_url"),
+            role=data.get("role"),
+        )
+
+    def to_dict(self) -> dict:
+        """Convert Organization to dictionary."""
+        return {
+            "login": self.login,
+            "name": self.name,
+            "id": self.id,
+            "description": self.description,
+            "url": self.url,
+            "avatar_url": self.avatar_url,
+            "role": self.role,
+        }
+
+
+@dataclass
+class TemplateRepo:
+    """
+    Represents a template repository (master or cloned).
+
+    Attributes:
+        name: Repository name (without owner prefix)
+        owner: Repository owner (org login or username)
+        full_name: Full repository name (owner/name)
+        url: HTML URL to repository on GitHub
+        clone_url: Git clone URL (HTTPS)
+        is_template: Whether the repo is marked as a GitHub template
+        private: Whether the repository is private
+        description: Repository description
+        local_path: Local filesystem path if cloned
+    """
+
+    name: str
+    owner: str
+    full_name: str = ""
+    url: str = ""
+    clone_url: str = ""
+    is_template: bool = False
+    private: bool = False
+    description: Optional[str] = None
+    local_path: Optional[Path] = None
+
+    def __post_init__(self):
+        if not self.full_name:
+            self.full_name = f"{self.owner}/{self.name}"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TemplateRepo":
+        """Create TemplateRepo from a GitHub API response dict."""
+        owner_login = (
+            data["owner"]["login"] if isinstance(data.get("owner"), dict) else data.get("owner", "")
+        )
+        return cls(
+            name=data.get("name", ""),
+            owner=owner_login,
+            full_name=data.get("full_name", ""),
+            url=data.get("html_url", ""),
+            clone_url=data.get("clone_url", ""),
+            is_template=data.get("is_template", False),
+            private=data.get("private", False),
+            description=data.get("description"),
+        )
+
+    def to_dict(self) -> dict:
+        """Convert TemplateRepo to dictionary."""
+        return {
+            "name": self.name,
+            "owner": self.owner,
+            "full_name": self.full_name,
+            "url": self.url,
+            "clone_url": self.clone_url,
+            "is_template": self.is_template,
+            "private": self.private,
+            "description": self.description,
+            "local_path": str(self.local_path) if self.local_path else None,
+        }
+
+
+@dataclass
+class WorkspaceFolder:
+    """
+    Represents a local workspace folder (master or semester org).
+
+    Attributes:
+        path: Absolute path to the workspace folder
+        is_master: True if this is a master template folder
+        course_code: Course code (e.g., CS3030)
+        org_name: GitHub org name this folder is linked to (None for master)
+        repos: List of template repos found in this folder
+    """
+
+    path: Path
+    is_master: bool = False
+    course_code: Optional[str] = None
+    org_name: Optional[str] = None
+    repos: List[TemplateRepo] = field(default_factory=list)
+
+    MASTER_MARKER = ".classdock-master"
+
+    @property
+    def marker_path(self) -> Path:
+        """Path to the master marker file."""
+        return self.path / self.MASTER_MARKER
+
+    def is_marked_as_master(self) -> bool:
+        """Check if this folder has the master marker file."""
+        return self.marker_path.exists()
+
+    def to_dict(self) -> dict:
+        """Convert WorkspaceFolder to dictionary."""
+        return {
+            "path": str(self.path),
+            "is_master": self.is_master,
+            "course_code": self.course_code,
+            "org_name": self.org_name,
+            "repos": [r.to_dict() for r in self.repos],
+        }
+
+
+@dataclass
+class CloneResult:
+    """
+    Result of a batch template cloning operation.
+
+    Attributes:
+        total: Total repositories attempted
+        successful: Successfully cloned count
+        failed: Failed clone count
+        cloned_repos: List of successfully cloned repos
+        errors: Error messages for failures
+    """
+
+    total: int = 0
+    successful: int = 0
+    failed: int = 0
+    cloned_repos: List[TemplateRepo] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    def add_success(self, repo: TemplateRepo) -> None:
+        """Record a successful clone."""
+        self.cloned_repos.append(repo)
+        self.successful += 1
+
+    def add_failure(self, error: str) -> None:
+        """Record a clone failure."""
+        self.errors.append(error)
+        self.failed += 1
+
+    @property
+    def success_rate(self) -> float:
+        """Return success rate as a percentage (0-100)."""
+        if self.total == 0:
+            return 0.0
+        return (self.successful / self.total) * 100
+
+
+@dataclass
+class SetupResult:
+    """
+    Result of the full organization setup wizard.
+
+    Attributes:
+        organization: The newly created or selected organization
+        workspace_folder: The local semester org folder created
+        clone_result: Results of template cloning
+        success: Whether the overall setup succeeded
+        error_message: Human-readable error if setup failed
+    """
+
+    organization: Optional[Organization] = None
+    workspace_folder: Optional[WorkspaceFolder] = None
+    clone_result: Optional[CloneResult] = None
+    success: bool = False
+    error_message: Optional[str] = None

--- a/classdock/organizations/templates.py
+++ b/classdock/organizations/templates.py
@@ -13,6 +13,7 @@ import time
 from typing import Callable, List, Optional
 
 from ..utils.github_api_client import GitHubAPIClient
+from ..utils.github_exceptions import RepoAlreadyExistsError
 from .models import CloneResult, TemplateRepo
 
 logger = logging.getLogger(__name__)
@@ -120,8 +121,8 @@ class TemplateManager:
             return TemplateRepo.from_dict(raw)
 
         # Fallback: try fork (for repos not marked as templates)
-        logger.warning(
-            "generate-from-template failed for '%s/%s'; falling back to fork.",
+        logger.debug(
+            "generate-from-template returned None for '%s/%s'; falling back to fork.",
             source_owner, repo_name,
         )
         raw = self._api.fork_repository(
@@ -194,14 +195,14 @@ class TemplateManager:
         Returns:
             CloneResult summarising successes and failures.
         """
-        result = CloneResult(total=len(repo_names))
+        result = CloneResult(total=len(repo_names), attempted_names=list(repo_names))
 
         for idx, name in enumerate(repo_names, start=1):
             if progress_callback:
                 progress_callback(idx, len(repo_names), name)
 
-            logger.info(
-                "Forking '%s/%s' → '%s' (%d/%d)",
+            logger.debug(
+                "Copying '%s/%s' → '%s' (%d/%d)",
                 source_org,
                 name,
                 target_org,
@@ -209,11 +210,16 @@ class TemplateManager:
                 len(repo_names),
             )
 
-            repo = self.copy_template_repository(
-                source_owner=source_org,
-                repo_name=name,
-                target_org=target_org,
-            )
+            try:
+                repo = self.copy_template_repository(
+                    source_owner=source_org,
+                    repo_name=name,
+                    target_org=target_org,
+                )
+            except RepoAlreadyExistsError:
+                logger.debug("'%s/%s' already exists; skipping.", target_org, name)
+                result.add_already_existed(name)
+                continue
 
             if repo is None:
                 error_msg = f"Failed to fork '{source_org}/{name}' into '{target_org}'"
@@ -240,11 +246,12 @@ class TemplateManager:
                 repo.is_template = True
 
             result.add_success(repo)
-            logger.info("✓ Cloned and configured '%s/%s'", target_org, repo.name)
+            logger.debug("Cloned and configured '%s/%s'", target_org, repo.name)
 
-        logger.info(
-            "Batch clone complete: %d/%d succeeded",
+        logger.debug(
+            "Batch clone complete: %d cloned, %d already existed, %d failed",
             result.successful,
-            result.total,
+            len(result.already_existed),
+            result.failed,
         )
         return result

--- a/classdock/organizations/templates.py
+++ b/classdock/organizations/templates.py
@@ -1,0 +1,250 @@
+"""
+Template repository management for organization setup.
+
+Handles:
+- Listing template repositories in a GitHub organization
+- Forking repositories from one org to another
+- Configuring forked repositories as GitHub templates
+- Batch cloning with progress tracking
+"""
+
+import logging
+import time
+from typing import Callable, List, Optional
+
+from ..utils.github_api_client import GitHubAPIClient
+from .models import CloneResult, TemplateRepo
+
+logger = logging.getLogger(__name__)
+
+# Seconds to wait after forking before marking a repo as template.
+# GitHub's fork API is asynchronous; the repo may not be fully ready immediately.
+_FORK_SETTLE_SECONDS = 3
+
+
+class TemplateManager:
+    """
+    Manages template repository operations between GitHub organizations.
+
+    Args:
+        token: GitHub personal access token.
+    """
+
+    def __init__(self, token: Optional[str] = None):
+        self._api = GitHubAPIClient(token=token)
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def list_org_templates(self, org_login: str) -> List[TemplateRepo]:
+        """
+        Return all repositories in an org that are marked as GitHub templates.
+
+        Args:
+            org_login: Organization login to search.
+
+        Returns:
+            Sorted list of TemplateRepo objects.
+        """
+        raw = self._api.list_org_repos(org_login, templates_only=True)
+        repos = [TemplateRepo.from_dict(r) for r in raw]
+        repos.sort(key=lambda r: r.name.lower())
+        logger.debug(
+            "Found %d template repos in '%s'", len(repos), org_login
+        )
+        return repos
+
+    def list_org_repos(
+        self, org_login: str, templates_only: bool = False
+    ) -> List[TemplateRepo]:
+        """
+        Return all repositories in an org.
+
+        Args:
+            org_login: Organization login.
+            templates_only: If True, return only template repos.
+
+        Returns:
+            Sorted list of TemplateRepo objects.
+        """
+        raw = self._api.list_org_repos(org_login, templates_only=templates_only)
+        repos = [TemplateRepo.from_dict(r) for r in raw]
+        repos.sort(key=lambda r: r.name.lower())
+        return repos
+
+    # ------------------------------------------------------------------
+    # Individual repo operations
+    # ------------------------------------------------------------------
+
+    def copy_template_repository(
+        self,
+        source_owner: str,
+        repo_name: str,
+        target_org: str,
+        new_name: Optional[str] = None,
+        private: bool = True,
+    ) -> Optional[TemplateRepo]:
+        """
+        Create a new repository in target_org from a GitHub template repository.
+
+        Uses the "generate from template" API which works even when forking is
+        disabled on the source repo.  The source repo must be marked as a GitHub
+        template (``is_template: true``).
+
+        Falls back to the fork API if the generate endpoint returns 404
+        (e.g., the repo is not marked as a template).
+
+        Args:
+            source_owner: Source org/user login.
+            repo_name: Repository name in the source org.
+            target_org: Target organization login.
+            new_name: Name for the new repo (defaults to repo_name).
+            private: Whether the created repo should be private.
+
+        Returns:
+            TemplateRepo representing the new repo, or None on failure.
+        """
+        dest_name = new_name or repo_name
+
+        # Primary: generate from template
+        raw = self._api.create_from_template(
+            template_owner=source_owner,
+            template_repo=repo_name,
+            target_owner=target_org,
+            new_name=dest_name,
+            private=private,
+        )
+
+        if raw is not None:
+            return TemplateRepo.from_dict(raw)
+
+        # Fallback: try fork (for repos not marked as templates)
+        logger.warning(
+            "generate-from-template failed for '%s/%s'; falling back to fork.",
+            source_owner, repo_name,
+        )
+        raw = self._api.fork_repository(
+            owner=source_owner,
+            repo=repo_name,
+            target_org=target_org,
+            new_name=new_name,
+        )
+        if raw is None:
+            return None
+        return TemplateRepo.from_dict(raw)
+
+    def fork_repository(
+        self,
+        source_owner: str,
+        repo_name: str,
+        target_org: str,
+        new_name: Optional[str] = None,
+    ) -> Optional[TemplateRepo]:
+        """Fork a single repository into the target organization (legacy path)."""
+        raw = self._api.fork_repository(
+            owner=source_owner,
+            repo=repo_name,
+            target_org=target_org,
+            new_name=new_name,
+        )
+        if raw is None:
+            return None
+        return TemplateRepo.from_dict(raw)
+
+    def make_template(self, owner: str, repo_name: str) -> bool:
+        """
+        Mark a repository as a GitHub template (``is_template = true``).
+
+        Args:
+            owner: Repository owner login.
+            repo_name: Repository name.
+
+        Returns:
+            True if the update succeeded.
+        """
+        return self._api.set_repository_template(owner, repo_name, is_template=True)
+
+    # ------------------------------------------------------------------
+    # Batch operations
+    # ------------------------------------------------------------------
+
+    def clone_templates(
+        self,
+        source_org: str,
+        target_org: str,
+        repo_names: List[str],
+        progress_callback: Optional[Callable[[int, int, str], None]] = None,
+        settle_seconds: float = _FORK_SETTLE_SECONDS,
+    ) -> CloneResult:
+        """
+        Fork a list of template repositories from source_org into target_org,
+        then configure each forked repo as a GitHub template.
+
+        Args:
+            source_org: Organization login to fork repos from.
+            target_org: Organization login to fork repos into.
+            repo_names: Names of repositories to fork.
+            progress_callback: Optional callback called after each repo with
+                               (current_index, total, repo_name). Useful for
+                               displaying a progress bar.
+            settle_seconds: Seconds to wait after each fork before setting the
+                            template flag (the fork API is async).
+
+        Returns:
+            CloneResult summarising successes and failures.
+        """
+        result = CloneResult(total=len(repo_names))
+
+        for idx, name in enumerate(repo_names, start=1):
+            if progress_callback:
+                progress_callback(idx, len(repo_names), name)
+
+            logger.info(
+                "Forking '%s/%s' → '%s' (%d/%d)",
+                source_org,
+                name,
+                target_org,
+                idx,
+                len(repo_names),
+            )
+
+            repo = self.copy_template_repository(
+                source_owner=source_org,
+                repo_name=name,
+                target_org=target_org,
+            )
+
+            if repo is None:
+                error_msg = f"Failed to fork '{source_org}/{name}' into '{target_org}'"
+                logger.error(error_msg)
+                result.add_failure(error_msg)
+                continue
+
+            # Allow GitHub to finish setting up the fork before patching it.
+            if settle_seconds > 0:
+                time.sleep(settle_seconds)
+
+            # Mark as a GitHub template repository
+            template_ok = self.make_template(owner=target_org, repo_name=repo.name)
+            if not template_ok:
+                logger.warning(
+                    "Forked '%s' but could not set is_template flag on '%s/%s'",
+                    name,
+                    target_org,
+                    repo.name,
+                )
+                # Still count as success — the fork worked, template flag is cosmetic
+                repo.is_template = False
+            else:
+                repo.is_template = True
+
+            result.add_success(repo)
+            logger.info("✓ Cloned and configured '%s/%s'", target_org, repo.name)
+
+        logger.info(
+            "Batch clone complete: %d/%d succeeded",
+            result.successful,
+            result.total,
+        )
+        return result

--- a/classdock/organizations/validators.py
+++ b/classdock/organizations/validators.py
@@ -1,0 +1,195 @@
+"""
+Naming convention validation for GitHub organizations.
+
+Enforces the ClassDock organization naming standard:
+  [SUBJECT]-[COURSE][SECTION?]-[LASTNAME]-[SEMESTER][YEAR]
+
+Examples:
+  SOC-CS3030-Valle-SU26        (single section)
+  SOC-CS3550-2-Smith-SP26      (section 2)
+  SOC-WEB1400-Valle-FA25
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Regex: SUBJECT-COURSE(-SECTION)?-LASTNAME-SEMESTERYEAR
+_ORG_NAME_RE = re.compile(
+    r"^(?P<subject>[A-Z]{3,4})"
+    r"-(?P<course>[A-Z]+\d{4})"
+    r"(?:-(?P<section>\d))?"
+    r"-(?P<lastname>[A-Z][a-z]+)"
+    r"-(?P<semester>FA|SP|SU)(?P<year>\d{2})$"
+)
+
+VALID_SEMESTERS = {"FA", "SP", "SU"}
+SEMESTER_LABELS = {"FA": "Fall", "SP": "Spring", "SU": "Summer"}
+
+
+@dataclass
+class ValidationResult:
+    """
+    Result of an organization name validation.
+
+    Attributes:
+        is_valid: Whether the name passes all rules
+        error: Human-readable error message (None if valid)
+        subject: Parsed SUBJECT component
+        course: Parsed COURSE component (e.g., CS3030)
+        section: Parsed optional SECTION digit (None if absent)
+        lastname: Parsed LASTNAME component
+        semester: Parsed semester code (FA/SP/SU)
+        year: Parsed 2-digit year string
+    """
+
+    is_valid: bool
+    error: Optional[str] = None
+    subject: Optional[str] = None
+    course: Optional[str] = None
+    section: Optional[str] = None
+    lastname: Optional[str] = None
+    semester: Optional[str] = None
+    year: Optional[str] = None
+
+    @property
+    def semester_label(self) -> Optional[str]:
+        """Return the human-readable semester name (e.g., 'Fall')."""
+        if self.semester:
+            return SEMESTER_LABELS.get(self.semester)
+        return None
+
+    @property
+    def full_year(self) -> Optional[str]:
+        """Return 4-digit year string (e.g., '2026')."""
+        if self.year:
+            return f"20{self.year}"
+        return None
+
+
+class OrgNameValidator:
+    """Validates and constructs GitHub organization names per ClassDock convention."""
+
+    FORMAT = "[SUBJECT]-[COURSE][-SECTION]-[LASTNAME]-[SEMESTER][YEAR]"
+    EXAMPLE = "SOC-CS3030-Valle-SU26"
+
+    @staticmethod
+    def validate(name: str) -> ValidationResult:
+        """
+        Validate an organization name against the ClassDock naming convention.
+
+        Args:
+            name: The organization name to validate
+
+        Returns:
+            ValidationResult with parsed components if valid
+        """
+        if not name or not name.strip():
+            return ValidationResult(is_valid=False, error="Organization name cannot be empty.")
+
+        name = name.strip()
+
+        m = _ORG_NAME_RE.match(name)
+        if not m:
+            return ValidationResult(
+                is_valid=False,
+                error=(
+                    f"'{name}' does not match the required format: {OrgNameValidator.FORMAT}\n"
+                    f"  Example: {OrgNameValidator.EXAMPLE}\n"
+                    f"  Rules:\n"
+                    f"    SUBJECT  — 3–4 uppercase letters (e.g., SOC, WEB, CS)\n"
+                    f"    COURSE   — uppercase letters + 4-digit number (e.g., CS3030)\n"
+                    f"    SECTION  — optional single digit (e.g., 2)\n"
+                    f"    LASTNAME — capitalized last name (e.g., Valle)\n"
+                    f"    SEMESTER — FA, SP, or SU followed by 2-digit year (e.g., SU26)"
+                ),
+            )
+
+        return ValidationResult(
+            is_valid=True,
+            subject=m.group("subject"),
+            course=m.group("course"),
+            section=m.group("section"),
+            lastname=m.group("lastname"),
+            semester=m.group("semester"),
+            year=m.group("year"),
+        )
+
+    @staticmethod
+    def build(
+        subject: str,
+        course: str,
+        lastname: str,
+        semester: str,
+        year: str,
+        section: Optional[str] = None,
+    ) -> str:
+        """
+        Build a compliant organization name from individual components.
+
+        Args:
+            subject: 3–4 letter subject prefix (e.g., SOC)
+            course: Course code with number (e.g., CS3030)
+            lastname: Instructor's last name (e.g., Valle)
+            semester: Semester code — FA, SP, or SU
+            year: 2-digit year string (e.g., 26)
+            section: Optional single-digit section number
+
+        Returns:
+            Formatted organization name string
+
+        Raises:
+            ValueError: If the resulting name fails validation
+        """
+        subject = subject.upper().strip()
+        course = course.upper().strip()
+        lastname = lastname.strip().capitalize()
+        semester = semester.upper().strip()
+        year = year.strip()
+
+        parts = [subject, course]
+        if section:
+            parts.append(str(section).strip())
+        parts.append(lastname)
+        parts.append(f"{semester}{year}")
+
+        name = "-".join(parts)
+
+        result = OrgNameValidator.validate(name)
+        if not result.is_valid:
+            raise ValueError(f"Built name '{name}' is invalid: {result.error}")
+
+        return name
+
+    @staticmethod
+    def suggest(
+        subject: str,
+        course_number: str,
+        lastname: str,
+        semester: str,
+        year: str,
+        section: Optional[str] = None,
+    ) -> str:
+        """
+        Suggest an organization name, normalizing inputs leniently.
+
+        Useful for generating a preview before the user finalizes.
+        Does not raise on invalid input — returns best-effort string.
+        """
+        subject = re.sub(r"[^A-Za-z]", "", subject).upper()[:4]
+        course_number = re.sub(r"[^A-Za-z0-9]", "", course_number).upper()
+        lastname = re.sub(r"[^A-Za-z]", "", lastname).capitalize()
+        semester = semester.upper().strip()
+        if semester not in VALID_SEMESTERS:
+            semester = "FA"
+        year = re.sub(r"[^0-9]", "", year)[-2:]
+
+        parts = [subject, course_number]
+        if section:
+            sec = re.sub(r"[^0-9]", "", str(section))
+            if sec:
+                parts.append(sec)
+        parts.append(lastname)
+        parts.append(f"{semester}{year}")
+
+        return "-".join(parts)

--- a/classdock/organizations/wizard.py
+++ b/classdock/organizations/wizard.py
@@ -33,6 +33,7 @@ from ..utils.ui_components import (
     print_status,
     print_success,
 )
+from .classroom import ClassroomManager
 from .manager import OrganizationManager
 from .models import Organization, SetupResult, TemplateRepo, WorkspaceFolder
 from .templates import TemplateManager
@@ -130,7 +131,9 @@ class OrganizationSetupWizard:
             )
 
         # Step 9 — classroom guidance
-        self._step_classroom_guidance(org_name)
+        self._step_classroom_guidance(
+            org_name, org_folder=org_folder, source_org=source_org
+        )
 
         # Step 10 — generate assignment.conf
         self._step_generate_config(org_folder, org_name, github_org)
@@ -540,21 +543,153 @@ class OrganizationSetupWizard:
         print_success(f"Forked {result.successful}/{result.total} repo(s) to '{target_org}'")
         return result
 
-    def _step_classroom_guidance(self, org_name: str) -> None:
-        """Print guided next-steps for manual GitHub Classroom setup."""
+    def _step_classroom_guidance(
+        self,
+        org_name: str,
+        org_folder: Optional[WorkspaceFolder] = None,
+        source_org: Optional[str] = None,
+    ) -> None:
+        """
+        Guide the instructor through GitHub Classroom setup.
+
+        If the source org has an accessible classroom, offer to pre-populate
+        a clone checklist.  Otherwise fall back to static guidance.
+        """
+        # Try to find a source classroom to clone from
+        source_classroom_id: Optional[int] = None
+        if source_org and self.token:
+            try:
+                classroom_mgr = ClassroomManager(token=self.token)
+                source_classrooms = classroom_mgr.list_classrooms_for_org(source_org)
+                if source_classrooms:
+                    sc = source_classrooms[0]
+                    console.print(
+                        f"\nFound classroom [cyan]{sc.name}[/cyan] in source org "
+                        f"[bold]{source_org}[/bold]."
+                    )
+                    clone_it = typer.confirm(
+                        "Generate assignment checklist from this classroom?", default=True
+                    )
+                    if clone_it:
+                        source_classroom_id = sc.id
+            except Exception as exc:
+                logger.debug("Could not check source classrooms: %s", exc)
+
+        if source_classroom_id and self.token:
+            self._generate_classroom_checklist(
+                source_classroom_id=source_classroom_id,
+                target_org=org_name,
+                org_folder=org_folder,
+            )
+        else:
+            # Static fallback guidance
+            console.print(
+                Panel(
+                    "[bold]GitHub Classroom — Manual Setup Required[/bold]\n\n"
+                    "The GitHub Classroom API does not support classroom creation.\n"
+                    "Please follow these steps:\n\n"
+                    f"  1. Go to [link=https://classroom.github.com/classrooms/new]"
+                    f"https://classroom.github.com/classrooms/new[/link]\n"
+                    f"  2. Select organization: [cyan]{org_name}[/cyan]\n"
+                    f"  3. Name your classroom (e.g., 'CS3030 Fall 2026')\n"
+                    f"  4. Click 'Create classroom'\n"
+                    f"  5. Create assignments using the template repos now in '{org_name}'\n\n"
+                    f"  Once done, run: [bold]classdock assignments setup[/bold]\n\n"
+                    f"  To clone an existing classroom structure later:\n"
+                    f"  [bold]classdock organizations classroom clone <ID> {org_name}[/bold]",
+                    title="Next Steps",
+                    border_style="blue",
+                )
+            )
+
+    def _generate_classroom_checklist(
+        self,
+        source_classroom_id: int,
+        target_org: str,
+        org_folder: Optional[WorkspaceFolder] = None,
+    ) -> None:
+        """Clone starter repos from a source classroom and generate a setup checklist."""
+        from pathlib import Path as _Path
+
+        classroom_mgr = ClassroomManager(token=self.token)
+        assignments = classroom_mgr.list_assignments(source_classroom_id)
+        if not assignments:
+            console.print("[yellow]No assignments found in source classroom.[/yellow]")
+            return
+
+        # Find target classroom (may not exist yet)
+        target_classrooms = classroom_mgr.list_classrooms_for_org(target_org)
+        target_classroom_id = target_classrooms[0].id if target_classrooms else None
+
+        rows = []
+        for a in assignments:
+            starter = a.starter_code_repo
+            cloned_status = "—"
+            new_repo: Optional[str] = None
+
+            if starter and not self.dry_run:
+                owner, _, repo_name = starter.partition("/")
+                try:
+                    result = self._template_manager.copy_template_repository(
+                        source_owner=owner,
+                        repo_name=repo_name,
+                        target_org=target_org,
+                    )
+                    new_repo = f"{target_org}/{repo_name}"
+                    cloned_status = "✓ cloned" if result else "✗ failed"
+                except Exception:
+                    new_repo = f"{target_org}/{repo_name}"
+                    cloned_status = "↩ exists"
+            elif starter:
+                _, _, repo_name = starter.partition("/")
+                new_repo = f"{target_org}/{repo_name}"
+                cloned_status = "[dry-run]"
+
+            create_url = (
+                ClassroomManager.assignment_creation_url(target_classroom_id, new_repo)
+                if target_classroom_id
+                else ClassroomManager.new_classroom_url()
+            )
+            rows.append((a.title, a.type, a.deadline or "—", cloned_status, create_url))
+
+        # Display table
+        table = Table(title=f"Assignment Checklist → {target_org}", show_header=True)
+        table.add_column("Assignment", style="cyan")
+        table.add_column("Type", justify="center")
+        table.add_column("Deadline")
+        table.add_column("Starter Repo", justify="center")
+        table.add_column("Create URL")
+        for title, atype, deadline, status, url in rows:
+            table.add_row(title, atype, deadline, status, url)
+        console.print(table)
+
+        # Write classroom_setup.md
+        ws_path = org_folder.path if org_folder else _Path.cwd()
+        md_path = ws_path / "classroom_setup.md"
+        if not self.dry_run:
+            lines = [
+                f"# Classroom Setup → {target_org}\n\n",
+                "Create the following assignments in your GitHub Classroom.\n\n",
+                "| Assignment | Type | Deadline | Create URL |\n",
+                "|---|---|---|---|\n",
+            ]
+            for title, atype, deadline, _, url in rows:
+                lines.append(f"| {title} | {atype} | {deadline} | {url} |\n")
+            md_path.write_text("".join(lines), encoding="utf-8")
+
         console.print(
             Panel(
-                "[bold]GitHub Classroom — Manual Setup Required[/bold]\n\n"
-                "The GitHub Classroom API does not support classroom creation.\n"
-                "Please follow these steps:\n\n"
-                f"  1. Go to [link=https://classroom.github.com/classrooms/new]"
-                f"https://classroom.github.com/classrooms/new[/link]\n"
-                f"  2. Select organization: [cyan]{org_name}[/cyan]\n"
-                f"  3. Name your classroom (e.g., 'CS3030 Summer 2026')\n"
-                f"  4. Click 'Create classroom'\n"
-                f"  5. Create assignments using the template repos now in '{org_name}'\n\n"
-                f"  Once done, run: [bold]classdock assignments setup[/bold]",
-                title="Next Steps",
+                "[bold]Next steps:[/bold]\n\n"
+                + (
+                    f"  A classroom already exists for {target_org}.\n"
+                    f"  Use the Create URLs above to add each assignment.\n"
+                    if target_classroom_id
+                    else f"  1. Create a classroom for [cyan]{target_org}[/cyan]:\n"
+                    f"     {ClassroomManager.new_classroom_url()}\n"
+                    f"  2. Use the Create URLs in the checklist above.\n"
+                )
+                + (f"\n  Checklist saved to: {md_path}" if not self.dry_run else ""),
+                title="GitHub Classroom",
                 border_style="blue",
             )
         )

--- a/classdock/organizations/wizard.py
+++ b/classdock/organizations/wizard.py
@@ -665,6 +665,7 @@ class OrganizationSetupWizard:
 
         # Write classroom_setup.md
         ws_path = org_folder.path if org_folder else _Path.cwd()
+        ws_path.mkdir(parents=True, exist_ok=True)
         md_path = ws_path / "classroom_setup.md"
         if not self.dry_run:
             lines = [

--- a/classdock/organizations/wizard.py
+++ b/classdock/organizations/wizard.py
@@ -1,0 +1,593 @@
+"""
+Organization setup wizard for ClassDock.
+
+Guides the instructor interactively through the full workflow:
+
+  1. Verify GitHub token scopes
+  2. Detect or prompt for the master template folder
+  3. List and select template repos to carry forward
+  4. Build and validate the new org name
+  5. Create the local semester org folder
+  6. Clone selected templates locally
+  7. Create the GitHub organization (requires admin:org scope)
+  8. Fork each local repo to the new GitHub org and mark as template
+  9. Guide through manual GitHub Classroom setup (API limitation)
+  10. Generate assignment.conf in the new org folder
+
+All I/O is done via ``rich`` console for a consistent look.
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from rich.text import Text
+
+from ..utils.ui_components import (
+    print_error,
+    print_status,
+    print_success,
+)
+from .manager import OrganizationManager
+from .models import Organization, SetupResult, TemplateRepo, WorkspaceFolder
+from .templates import TemplateManager
+from .validators import OrgNameValidator
+from .workspace import WorkspaceManager
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+class OrganizationSetupWizard:
+    """
+    Interactive wizard for setting up a new GitHub organization and local workspace.
+
+    Args:
+        token: GitHub personal access token.
+        dry_run: If True, print what would happen but make no changes.
+    """
+
+    def __init__(self, token: Optional[str] = None, dry_run: bool = False):
+        self.token = token
+        self.dry_run = dry_run
+        self._org_manager = OrganizationManager(token=token)
+        self._template_manager = TemplateManager(token=token)
+        self._workspace_manager = WorkspaceManager()
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> SetupResult:
+        """
+        Execute the full organization setup wizard.
+
+        Returns:
+            SetupResult summarising the outcome.
+        """
+        self._show_org_welcome()
+
+        # Step 1 — token scopes
+        if not self._step_verify_token():
+            return SetupResult(
+                success=False,
+                error_message="Token verification failed. Run `classdock config token` to update.",
+            )
+
+        # Step 2 — master folder
+        master_folder = self._step_select_master_folder()
+        if master_folder is None:
+            return SetupResult(
+                success=False, error_message="No master template folder selected."
+            )
+
+        # Step 2b — pick the source GitHub org (filters the repo list)
+        source_org = self._step_select_source_org(master_folder)
+        if not source_org:
+            return SetupResult(success=False, error_message="No source organization selected.")
+
+        # Step 3 — select template repos (filtered to source_org only)
+        selected_repos = self._step_select_templates(master_folder, source_org=source_org)
+        if not selected_repos:
+            console.print("[yellow]No templates selected. Setup cancelled.[/yellow]")
+            return SetupResult(success=False, error_message="No templates selected.")
+
+        # Step 4 — org name
+        org_name = self._step_collect_org_name()
+        if not org_name:
+            return SetupResult(success=False, error_message="No organization name provided.")
+
+        # Step 5 — create local folder
+        base_dir = master_folder.path.parent
+        org_folder = self._step_create_org_folder(base_dir, org_name)
+        if org_folder is None:
+            return SetupResult(
+                success=False, error_message="Failed to create local org folder."
+            )
+
+        # Step 6 — clone templates locally
+        self._step_clone_locally(selected_repos, org_folder)
+
+        # Step 7 — create GitHub organization
+        github_org = self._step_create_github_org(org_name)
+        if github_org is None:
+            console.print(
+                "[yellow]GitHub organization not created. "
+                "Proceed with manual org creation and re-run.[/yellow]"
+            )
+
+        # Step 8 — fork repos to GitHub org (each repo forked from its own source org)
+        clone_result = None
+        if github_org is not None:
+            clone_result = self._step_fork_to_github(
+                target_org=org_name,
+                repos=selected_repos,
+            )
+
+        # Step 9 — classroom guidance
+        self._step_classroom_guidance(org_name)
+
+        # Step 10 — generate assignment.conf
+        self._step_generate_config(org_folder, org_name, github_org)
+
+        console.print()
+        console.print(
+            Panel(
+                f"[green bold]✓ Organization workspace ready![/green bold]\n\n"
+                f"  Local folder:  {org_folder.path}\n"
+                f"  GitHub org:    https://github.com/{org_name}\n\n"
+                f"  Next: [bold]classdock assignments setup[/bold]",
+                title="Setup Complete",
+                border_style="green",
+            )
+        )
+
+        return SetupResult(
+            organization=github_org,
+            workspace_folder=org_folder,
+            clone_result=clone_result,
+            success=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Welcome screen
+    # ------------------------------------------------------------------
+
+    def _show_org_welcome(self) -> None:
+        """Display the organization setup wizard welcome panel."""
+        content = Text.assemble(
+            ("🏫 ClassDock — New Semester Organization Setup\n\n", "bold magenta"),
+            ("This wizard sets up a GitHub organization and local workspace\n", "white"),
+            ("for a new semester, ready for GitHub Classroom assignments.\n\n", "white"),
+            ("✨ What this wizard will do:\n", "bold green"),
+            ("   • Verify your GitHub token scopes\n", "white"),
+            ("   • Detect your master template folder (e.g., CS3030/)\n", "white"),
+            ("   • Let you select which template repos to carry forward\n", "white"),
+            ("   • Build and validate the new organization name\n", "white"),
+            ("   • Create a local semester org folder\n", "white"),
+            ("   • Clone selected templates locally\n", "white"),
+            ("   • Guide you to create the GitHub organization\n", "white"),
+            ("   • Fork templates into the new org as GitHub templates\n\n", "white"),
+            ("📋 You'll need:\n", "bold blue"),
+            ("   • A master template folder with cloned assignment repos\n", "white"),
+            ("   • New organization name (e.g., SOC-CS3030-Valle-SU26)\n", "white"),
+            ("   • GitHub token with repo + admin:org scopes\n", "white"),
+            ("   • A billing email for the new organization\n", "white"),
+        )
+        console.print(Panel(content, border_style="cyan"))
+
+    # ------------------------------------------------------------------
+    # Individual wizard steps
+    # ------------------------------------------------------------------
+
+    def _step_verify_token(self) -> bool:
+        """Verify GitHub token scopes. Return False if critical scopes are missing."""
+        print_status("Verifying GitHub token scopes…")
+        scopes = self._org_manager.get_token_scopes()
+
+        table = Table(title="Token Scopes", show_header=True)
+        table.add_column("Scope", style="cyan")
+        table.add_column("Status", style="bold")
+
+        required = {"repo": "Repository access", "admin:org": "Organization creation"}
+        all_ok = True
+        for scope, label in required.items():
+            if scope in scopes:
+                table.add_row(f"{scope} ({label})", "[green]✓ present[/green]")
+            else:
+                table.add_row(f"{scope} ({label})", "[red]✗ missing[/red]")
+                all_ok = False
+
+        console.print(table)
+
+        if not all_ok:
+            print_error(
+                "Token is missing required scopes.\n"
+                "Visit https://github.com/settings/tokens and add: admin:org, repo"
+            )
+        else:
+            print_success("Token scopes verified.")
+
+        return all_ok
+
+    def _step_select_master_folder(self) -> Optional[WorkspaceFolder]:
+        """Detect or prompt for the master template folder."""
+        print_status("Looking for master template folder…")
+
+        detected = self._workspace_manager.find_master_folder()
+        if detected:
+            console.print(f"  Found: [cyan]{detected.path}[/cyan]")
+            if typer.confirm("  Use this as the master template folder?", default=True):
+                return detected
+
+        # Manual entry
+        while True:
+            raw = typer.prompt(
+                "  Enter the path to your master template folder",
+                default=str(Path.cwd()),
+            )
+            path = Path(raw).expanduser().resolve()
+            if not path.is_dir():
+                print_error(f"Directory not found: {path}")
+                continue
+
+            wf = self._workspace_manager.find_master_folder(start=path)
+            if wf:
+                return wf
+
+            # Path exists but isn't marked — offer to initialize it
+            if typer.confirm(
+                f"  '{path}' is not a master folder. Initialize it as one?",
+                default=True,
+            ):
+                course_code = typer.prompt("  Course code (e.g., CS3030)")
+                return self._workspace_manager.init_master_folder(path, course_code)
+
+    def _step_select_source_org(self, master_folder: WorkspaceFolder) -> Optional[str]:
+        """
+        Ask the user which source GitHub organization the template repos belong to.
+
+        Detects all distinct owners from the local git remotes and presents them
+        as a numbered list.  The most common owner is offered as the default.
+        """
+        all_repos = master_folder.repos
+        if not all_repos:
+            return None
+
+        # Count how many repos each owner has
+        from collections import Counter
+        owner_counts = Counter(r.owner for r in all_repos if r.owner)
+
+        if not owner_counts:
+            return typer.prompt("  Enter the source GitHub organization (e.g., cs3030-master)")
+
+        # Sort by frequency (most common first)
+        ranked = owner_counts.most_common()
+
+        if len(ranked) == 1:
+            org = ranked[0][0]
+            console.print(f"\n  Source GitHub org detected: [cyan]{org}[/cyan]")
+            if typer.confirm(f"  Use '{org}' as the source organization?", default=True):
+                return org
+            return typer.prompt("  Enter the source GitHub organization")
+
+        console.print("\n[bold]Source GitHub organizations found in master folder:[/bold]\n")
+        for i, (owner, count) in enumerate(ranked, start=1):
+            console.print(f"  {i}. [cyan]{owner}[/cyan]  ({count} repo(s))")
+
+        console.print()
+        raw = typer.prompt(
+            "  Select source org number",
+            default="1",
+        )
+        try:
+            idx = int(raw.strip()) - 1
+            if 0 <= idx < len(ranked):
+                return ranked[idx][0]
+        except ValueError:
+            pass
+
+        return typer.prompt("  Enter the source GitHub organization")
+
+    def _step_select_templates(
+        self, master_folder: WorkspaceFolder, source_org: Optional[str] = None
+    ) -> List[TemplateRepo]:
+        """List repos that belong to source_org and let the user multi-select."""
+        all_repos = master_folder.repos
+
+        # Filter to the chosen source org
+        repos = (
+            [r for r in all_repos if r.owner == source_org]
+            if source_org
+            else all_repos
+        )
+
+        if not repos:
+            console.print(
+                f"[yellow]No repos from '{source_org}' found in {master_folder.path}.[/yellow]\n"
+                "  Make sure the repos are cloned there with the correct git remote."
+            )
+            return []
+
+        console.print(
+            f"\nFound [bold]{len(repos)}[/bold] repo(s) from "
+            f"[cyan]{source_org}[/cyan] in master folder:\n"
+        )
+        for i, repo in enumerate(repos, start=1):
+            console.print(f"  {i:2d}. [cyan]{repo.name}[/cyan]")
+
+        console.print()
+        raw = typer.prompt(
+            "Select repos to include (comma-separated numbers, or 'all')",
+            default="all",
+        )
+
+        if raw.strip().lower() == "all":
+            return repos
+
+        selected = []
+        for part in raw.split(","):
+            try:
+                idx = int(part.strip()) - 1
+                if 0 <= idx < len(repos):
+                    selected.append(repos[idx])
+            except ValueError:
+                pass
+
+        if not selected:
+            console.print("[yellow]No valid selections.[/yellow]")
+        return selected
+
+    def _step_collect_org_name(self) -> Optional[str]:
+        """Prompt for and validate the new GitHub organization name."""
+        console.print(
+            "\n[bold]Organization Naming Convention:[/bold]\n"
+            "  [SUBJECT]-[COURSE][-SECTION]-[LASTNAME]-[SEMESTER][YEAR]\n"
+            "  Example: SOC-CS3030-Valle-SU26\n"
+        )
+
+        # Offer component-by-component guidance
+        if typer.confirm("Build org name from components?", default=True):
+            return self._build_org_name_interactively()
+
+        # Free-form entry with validation
+        while True:
+            name = typer.prompt("Enter organization name").strip()
+            result = OrgNameValidator.validate(name)
+            if result.is_valid:
+                return name
+            print_error(result.error)
+            if not typer.confirm("Try again?", default=True):
+                return None
+
+    def _build_org_name_interactively(self) -> Optional[str]:
+        """Prompt for each component individually and build a validated name."""
+        subject = typer.prompt("  SUBJECT (3-4 uppercase letters, e.g., SOC)").strip().upper()
+        course = typer.prompt("  COURSE (letters + 4 digits, e.g., CS3030)").strip().upper()
+        section_raw = typer.prompt("  SECTION (single digit, press Enter to skip)", default="")
+        section = section_raw.strip() or None
+        lastname = typer.prompt("  LASTNAME (your last name, e.g., Valle)").strip()
+        semester = typer.prompt("  SEMESTER (FA / SP / SU)").strip().upper()
+        year = typer.prompt("  YEAR (2-digit, e.g., 26)").strip()
+
+        try:
+            name = OrgNameValidator.build(subject, course, lastname, semester, year, section)
+            console.print(f"\n  Generated name: [green bold]{name}[/green bold]")
+            if typer.confirm("  Use this name?", default=True):
+                return name
+            return None
+        except ValueError as exc:
+            print_error(str(exc))
+            return None
+
+    def _step_create_org_folder(
+        self, base: Path, org_name: str
+    ) -> Optional[WorkspaceFolder]:
+        """Create the local semester org folder."""
+        if self.dry_run:
+            console.print(
+                f"[dry-run] Would create folder: {base / org_name}"
+            )
+            return WorkspaceFolder(path=base / org_name, org_name=org_name)
+
+        existing = self._workspace_manager.find_org_folder(base, org_name)
+        if existing:
+            console.print(
+                f"  [yellow]Folder already exists: {existing.path}[/yellow]"
+            )
+            if not typer.confirm("  Continue using existing folder?", default=True):
+                return None
+            return existing
+
+        try:
+            folder = self._workspace_manager.create_org_folder(base, org_name)
+            print_success(f"Created local folder: {folder.path}")
+            return folder
+        except Exception as exc:
+            print_error(f"Failed to create folder: {exc}")
+            return None
+
+    def _step_clone_locally(
+        self, repos: List[TemplateRepo], org_folder: WorkspaceFolder
+    ) -> None:
+        """Clone selected templates into the local org folder."""
+        if self.dry_run:
+            console.print(
+                f"[dry-run] Would clone {len(repos)} repo(s) into {org_folder.path}"
+            )
+            return
+
+        print_status(f"Cloning {len(repos)} template(s) locally…")
+
+        def progress(cur, total, name):
+            console.print(f"  [{cur}/{total}] Cloning {name}…")
+
+        repos_with_url = [r for r in repos if r.clone_url]
+        if not repos_with_url:
+            console.print(
+                "[yellow]  No clone URLs found on local repos. "
+                "Skipping local clone step.[/yellow]"
+            )
+            return
+
+        self._workspace_manager.clone_templates_locally(
+            repos_with_url, org_folder.path, progress_callback=progress
+        )
+
+    def _step_create_github_org(self, org_name: str) -> Optional[Organization]:
+        """Create the GitHub organization, handling known errors gracefully."""
+        print_status(f"Creating GitHub organization '{org_name}'…")
+
+        if self.dry_run:
+            console.print(f"[dry-run] Would create GitHub org: {org_name}")
+            return Organization(login=org_name)
+
+        # Check if org already exists
+        if self._org_manager.organization_exists(org_name):
+            console.print(
+                f"  [yellow]Organization '{org_name}' already exists on GitHub.[/yellow]"
+            )
+            if typer.confirm("  Use existing organization?", default=True):
+                return self._org_manager.get_organization(org_name)
+            return None
+
+        billing_email = typer.prompt("  Billing contact email for the new organization")
+
+        try:
+            org = self._org_manager.create_organization(
+                login=org_name,
+                billing_email=billing_email,
+            )
+            print_success(f"Organization created: https://github.com/{org_name}")
+            return org
+        except NotImplementedError as exc:
+            console.print(f"\n[yellow]{exc}[/yellow]\n")
+            console.print(
+                "Once you have created the organization manually, press Enter to continue."
+            )
+            typer.prompt("  Press Enter when the org is ready", default="", show_default=False)
+            # Verify the org now exists
+            if self._org_manager.organization_exists(org_name):
+                print_success(f"Organization '{org_name}' confirmed on GitHub.")
+                return self._org_manager.get_organization(org_name)
+            else:
+                print_error(f"Organization '{org_name}' not found. Continuing without GitHub org.")
+                return None
+        except PermissionError as exc:
+            print_error(str(exc))
+            return None
+        except Exception as exc:
+            print_error(f"Organization creation failed: {exc}")
+            if typer.confirm("  Continue setup without creating the org?", default=True):
+                return None
+            raise
+
+    def _step_fork_to_github(
+        self, target_org: str, repos: List[TemplateRepo]
+    ):
+        """
+        Fork selected repos to the new GitHub org.
+
+        Each repo is forked from its own source org (read from the git remote),
+        so repos from different organizations are handled correctly.
+        """
+        print_status(f"Forking {len(repos)} repo(s) to '{target_org}'…")
+
+        if self.dry_run:
+            for repo in repos:
+                console.print(
+                    f"  [dim][dry-run] Would fork {repo.owner}/{repo.name} → {target_org}[/dim]"
+                )
+            return None
+
+        from .models import CloneResult
+
+        result = CloneResult(total=len(repos))
+
+        for idx, repo in enumerate(repos, start=1):
+            console.print(
+                f"  [{idx}/{len(repos)}] Forking [cyan]{repo.owner}/{repo.name}[/cyan]…"
+            )
+            forked = self._template_manager.copy_template_repository(
+                source_owner=repo.owner,
+                repo_name=repo.name,
+                target_org=target_org,
+            )
+            if forked is None:
+                error_msg = f"Failed to copy '{repo.owner}/{repo.name}' into '{target_org}'"
+                result.add_failure(error_msg)
+                console.print(f"    [red]✗ {error_msg}[/red]")
+                continue
+
+            # Brief pause then mark as template
+            import time
+            time.sleep(3)
+            ok = self._template_manager.make_template(target_org, forked.name)
+            forked.is_template = ok
+            result.add_success(forked)
+            console.print(f"    [green]✓ {target_org}/{forked.name}[/green]")
+
+        if result.failed > 0:
+            console.print(f"\n  [yellow]{result.failed} fork(s) failed:[/yellow]")
+            for err in result.errors:
+                console.print(f"    • {err}")
+
+        print_success(f"Forked {result.successful}/{result.total} repo(s) to '{target_org}'")
+        return result
+
+    def _step_classroom_guidance(self, org_name: str) -> None:
+        """Print guided next-steps for manual GitHub Classroom setup."""
+        console.print(
+            Panel(
+                "[bold]GitHub Classroom — Manual Setup Required[/bold]\n\n"
+                "The GitHub Classroom API does not support classroom creation.\n"
+                "Please follow these steps:\n\n"
+                f"  1. Go to [link=https://classroom.github.com/classrooms/new]"
+                f"https://classroom.github.com/classrooms/new[/link]\n"
+                f"  2. Select organization: [cyan]{org_name}[/cyan]\n"
+                f"  3. Name your classroom (e.g., 'CS3030 Summer 2026')\n"
+                f"  4. Click 'Create classroom'\n"
+                f"  5. Create assignments using the template repos now in '{org_name}'\n\n"
+                f"  Once done, run: [bold]classdock assignments setup[/bold]",
+                title="Next Steps",
+                border_style="blue",
+            )
+        )
+
+    def _step_generate_config(
+        self,
+        org_folder: WorkspaceFolder,
+        org_name: str,
+        github_org: Optional[Organization],
+    ) -> None:
+        """Write a minimal assignment.conf into the org folder."""
+        if self.dry_run:
+            console.print(f"[dry-run] Would write assignment.conf to {org_folder.path}")
+            return
+
+        config_path = org_folder.path / "assignment.conf"
+        if config_path.exists():
+            logger.debug("assignment.conf already exists; skipping generation.")
+            return
+
+        content = (
+            "# ClassDock Assignment Configuration\n"
+            f"# Generated for organization: {org_name}\n\n"
+            f"GITHUB_ORGANIZATION={org_name}\n"
+            "CLASSROOM_URL=\n"
+            "TEMPLATE_REPO_URL=\n"
+            "ASSIGNMENT_NAME=\n"
+            "STUDENT_FILES=\n\n"
+            "# Workflow\n"
+            "STEP_SYNC_TEMPLATE=true\n"
+            "STEP_DISCOVER_REPOS=true\n"
+            "STEP_MANAGE_SECRETS=false\n"
+            "STEP_ASSIST_STUDENTS=false\n"
+        )
+        config_path.write_text(content, encoding="utf-8")
+        print_success(f"Generated assignment.conf at {config_path}")

--- a/classdock/organizations/workspace.py
+++ b/classdock/organizations/workspace.py
@@ -1,0 +1,302 @@
+"""
+Local workspace folder management for organization-level assignment structure.
+
+The ClassDock workspace follows this convention:
+
+    ~/courses/                               ← configurable base dir
+    ├── CS3030/                              ← master template folder
+    │   ├── .classdock-master               ← marker identifying master folder
+    │   ├── python-basics/                   ← local git clone of template repo
+    │   └── midterm-project/
+    └── SOC-CS3030-Valle-SU26/              ← semester org folder
+        ├── .classdock-org                  ← marker with org name
+        ├── assignment.conf                  ← generated classdock config
+        ├── python-basics/                   ← cloned from master
+        └── midterm-project/
+
+This module provides WorkspaceManager which handles all local filesystem
+operations.  GitHub API operations are handled by the manager and templates
+modules.
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+from ..utils.paths import PathManager
+from .models import TemplateRepo, WorkspaceFolder
+
+logger = logging.getLogger(__name__)
+
+_MASTER_MARKER = ".classdock-master"
+_ORG_MARKER = ".classdock-org"
+
+
+class WorkspaceManager:
+    """
+    Manages the local workspace folder structure for ClassDock organizations.
+
+    Args:
+        base_path: Starting path for workspace discovery. Defaults to CWD.
+    """
+
+    def __init__(self, base_path: Optional[Path] = None):
+        self._path_manager = PathManager(base_path or Path.cwd())
+
+    # ------------------------------------------------------------------
+    # Master folder operations
+    # ------------------------------------------------------------------
+
+    def find_master_folder(self, start: Optional[Path] = None) -> Optional[WorkspaceFolder]:
+        """
+        Search for the nearest master template folder above the given path.
+
+        The master folder is identified by the presence of a ``.classdock-master``
+        marker file.
+
+        Args:
+            start: Directory to start searching from. Defaults to the base_path
+                   supplied at construction time.
+
+        Returns:
+            WorkspaceFolder for the master folder, or None if not found.
+        """
+        path = self._path_manager.find_master_folder(start=start)
+        if path is None:
+            return None
+
+        wf = WorkspaceFolder(
+            path=path,
+            is_master=True,
+            course_code=path.name,
+        )
+        wf.repos = self._discover_repos_in_folder(path)
+        return wf
+
+    def init_master_folder(self, path: Path, course_code: str) -> WorkspaceFolder:
+        """
+        Initialize a directory as a master template folder.
+
+        Creates the directory (if it does not exist) and writes the
+        ``.classdock-master`` marker file.
+
+        Args:
+            path: Absolute path to the folder.
+            course_code: Course code to embed in the marker (e.g., CS3030).
+
+        Returns:
+            WorkspaceFolder representing the initialized folder.
+        """
+        path.mkdir(parents=True, exist_ok=True)
+        marker = path / _MASTER_MARKER
+        marker.write_text(course_code, encoding="utf-8")
+        logger.info("Initialized master folder: %s", path)
+
+        return WorkspaceFolder(path=path, is_master=True, course_code=course_code)
+
+    # ------------------------------------------------------------------
+    # Semester org folder operations
+    # ------------------------------------------------------------------
+
+    def create_org_folder(self, base: Path, org_name: str) -> WorkspaceFolder:
+        """
+        Create a semester org folder under the given base directory.
+
+        Args:
+            base: Parent directory (typically the same directory that
+                  contains the master folder).
+            org_name: GitHub organization name (e.g., SOC-CS3030-Valle-SU26).
+
+        Returns:
+            WorkspaceFolder representing the new semester org folder.
+        """
+        org_path = self._path_manager.ensure_org_folder(base, org_name)
+        logger.info("Created org folder: %s", org_path)
+        return WorkspaceFolder(path=org_path, is_master=False, org_name=org_name)
+
+    def find_org_folder(self, base: Path, org_name: str) -> Optional[WorkspaceFolder]:
+        """
+        Return a WorkspaceFolder if the org folder already exists under base.
+
+        Args:
+            base: Parent directory.
+            org_name: Organization name.
+
+        Returns:
+            WorkspaceFolder if the folder exists, None otherwise.
+        """
+        path = self._path_manager.get_org_folder(base, org_name)
+        if not path.exists():
+            return None
+        return WorkspaceFolder(
+            path=path,
+            is_master=False,
+            org_name=org_name,
+            repos=self._discover_repos_in_folder(path),
+        )
+
+    # ------------------------------------------------------------------
+    # Local git-clone operations
+    # ------------------------------------------------------------------
+
+    def clone_repo_locally(
+        self,
+        clone_url: str,
+        dest_folder: Path,
+        repo_name: str,
+    ) -> Optional[Path]:
+        """
+        Clone a git repository into ``<dest_folder>/<repo_name>``.
+
+        Args:
+            clone_url: HTTPS or SSH URL to clone from.
+            dest_folder: Parent directory.
+            repo_name: Name for the cloned directory.
+
+        Returns:
+            Path to the cloned directory, or None if cloning failed.
+        """
+        target = dest_folder / repo_name
+        if target.exists():
+            logger.info("Repo '%s' already exists locally; skipping clone.", repo_name)
+            return target
+
+        logger.info("Cloning '%s' → %s", clone_url, target)
+        try:
+            result = subprocess.run(
+                ["git", "clone", "--quiet", clone_url, str(target)],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                logger.error(
+                    "git clone failed for '%s': %s", clone_url, result.stderr.strip()
+                )
+                return None
+            return target
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            logger.error("git clone error for '%s': %s", clone_url, exc)
+            return None
+
+    def clone_templates_locally(
+        self,
+        repos: List[TemplateRepo],
+        dest_folder: Path,
+        progress_callback=None,
+    ) -> List[TemplateRepo]:
+        """
+        Clone a list of TemplateRepo objects locally into dest_folder.
+
+        Each repo's ``local_path`` is set on success.
+
+        Args:
+            repos: TemplateRepo objects with a populated ``clone_url``.
+            dest_folder: Directory to clone repos into.
+            progress_callback: Optional callable(current, total, repo_name).
+
+        Returns:
+            List of TemplateRepo objects that were cloned successfully
+            (with local_path set).
+        """
+        cloned = []
+        total = len(repos)
+
+        for idx, repo in enumerate(repos, start=1):
+            if progress_callback:
+                progress_callback(idx, total, repo.name)
+
+            if not repo.clone_url:
+                logger.warning("No clone_url for '%s'; skipping.", repo.name)
+                continue
+
+            local = self.clone_repo_locally(repo.clone_url, dest_folder, repo.name)
+            if local:
+                repo.local_path = local
+                cloned.append(repo)
+
+        return cloned
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+    # ------------------------------------------------------------------
+
+    def _discover_repos_in_folder(self, folder: Path) -> List[TemplateRepo]:
+        """
+        Return a TemplateRepo stub for each subdirectory that looks like a
+        git repository (contains a ``.git`` directory).
+
+        Reads each repo's ``origin`` remote URL to populate ``owner`` and
+        ``clone_url`` from the actual GitHub organization rather than the
+        local folder name.
+
+        Args:
+            folder: Folder to inspect.
+
+        Returns:
+            List of TemplateRepo objects (metadata from filesystem + git remote).
+        """
+        repos = []
+        try:
+            for child in sorted(folder.iterdir()):
+                if not (child.is_dir() and (child / ".git").exists()):
+                    continue
+
+                owner, clone_url = self._read_git_remote(child)
+                repos.append(
+                    TemplateRepo(
+                        name=child.name,
+                        owner=owner or folder.name,
+                        clone_url=clone_url,
+                        local_path=child,
+                    )
+                )
+        except PermissionError as exc:
+            logger.warning("Cannot read folder '%s': %s", folder, exc)
+        return repos
+
+    @staticmethod
+    def _read_git_remote(repo_path: Path):
+        """
+        Return (owner, clone_url) parsed from the ``origin`` remote of a local
+        git repository.  Returns (None, "") on failure.
+        """
+        import re as _re
+
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return None, ""
+
+            url = result.stdout.strip()
+            # HTTPS: https://github.com/ORG/REPO.git
+            m = _re.match(r"https?://github\.com/([^/]+)/[^/]+", url)
+            if m:
+                return m.group(1), url
+            # SSH: git@github.com:ORG/REPO.git
+            m = _re.match(r"git@github\.com:([^/]+)/[^/]+", url)
+            if m:
+                return m.group(1), url
+            return None, url
+        except Exception as exc:
+            logger.debug("Could not read git remote for '%s': %s", repo_path, exc)
+            return None, ""
+
+    def list_repos_in_folder(self, folder: Path) -> List[TemplateRepo]:
+        """
+        Public wrapper for discovering local git repos within a folder.
+
+        Args:
+            folder: Directory to inspect.
+
+        Returns:
+            List of TemplateRepo objects found.
+        """
+        return self._discover_repos_in_folder(folder)

--- a/classdock/services/organization_service.py
+++ b/classdock/services/organization_service.py
@@ -1,0 +1,156 @@
+"""
+Organization service layer for ClassDock.
+
+Provides high-level operations consumed by CLI commands:
+- Running the interactive setup wizard
+- Listing the user's GitHub organizations
+- Batch-cloning templates between organizations
+
+This service is thin — it delegates to OrganizationManager,
+TemplateManager, and OrganizationSetupWizard.
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+from ..organizations.manager import OrganizationManager
+from ..organizations.models import CloneResult, Organization, SetupResult
+from ..organizations.templates import TemplateManager
+from ..organizations.wizard import OrganizationSetupWizard
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationService:
+    """
+    Service for organization lifecycle management.
+
+    Args:
+        token: GitHub personal access token. Falls back to GITHUB_TOKEN env var.
+        dry_run: When True, no side effects are performed.
+        verbose: Enable verbose logging.
+        wizard_factory: Optional callable returning an OrganizationSetupWizard.
+                        Used for dependency injection in tests.
+    """
+
+    def __init__(
+        self,
+        token: Optional[str] = None,
+        dry_run: bool = False,
+        verbose: bool = False,
+        wizard_factory=None,
+    ):
+        self.token = token
+        self.dry_run = dry_run
+        self.verbose = verbose
+        self._org_manager = OrganizationManager(token=token)
+        self._template_manager = TemplateManager(token=token)
+
+        if wizard_factory is not None:
+            self._wizard_factory = wizard_factory
+        else:
+            self._wizard_factory = lambda: OrganizationSetupWizard(
+                token=token, dry_run=dry_run
+            )
+
+    # ------------------------------------------------------------------
+    # Wizard
+    # ------------------------------------------------------------------
+
+    def setup(self) -> Tuple[bool, str]:
+        """
+        Run the interactive organization setup wizard.
+
+        Returns:
+            (success: bool, message: str)
+        """
+        wizard = self._wizard_factory()
+        try:
+            result: SetupResult = wizard.run()
+            if result.success:
+                org_url = (
+                    f"https://github.com/{result.organization.login}"
+                    if result.organization
+                    else "N/A"
+                )
+                return True, f"Organization setup complete. GitHub org: {org_url}"
+            return False, result.error_message or "Setup did not complete."
+        except Exception as exc:
+            logger.error("Organization setup failed: %s", exc)
+            return False, str(exc)
+
+    # ------------------------------------------------------------------
+    # Organization listing
+    # ------------------------------------------------------------------
+
+    def list_organizations(self) -> List[Organization]:
+        """
+        Return the GitHub organizations the authenticated user belongs to.
+
+        Returns:
+            List of Organization objects, sorted alphabetically by login.
+        """
+        return self._org_manager.list_user_organizations()
+
+    def verify_organization(self, login: str) -> Tuple[bool, Optional[Organization]]:
+        """
+        Verify that an organization exists and return its details.
+
+        Args:
+            login: Organization login to verify.
+
+        Returns:
+            (exists: bool, organization: Organization | None)
+        """
+        org = self._org_manager.get_organization(login)
+        return (org is not None, org)
+
+    # ------------------------------------------------------------------
+    # Template cloning
+    # ------------------------------------------------------------------
+
+    def clone_templates(
+        self,
+        source_org: str,
+        target_org: str,
+        repo_names: List[str],
+    ) -> CloneResult:
+        """
+        Fork a list of template repositories from source_org into target_org.
+
+        After forking, each repository is marked as a GitHub template
+        (``is_template = true``).
+
+        Args:
+            source_org: Organization to fork repos from.
+            target_org: Organization to fork repos into.
+            repo_names: Names of repos to fork. If empty, all template repos
+                        in source_org are used.
+
+        Returns:
+            CloneResult with success/failure counts and details.
+        """
+        if not repo_names:
+            templates = self._template_manager.list_org_templates(source_org)
+            repo_names = [t.name for t in templates]
+            logger.info(
+                "No repos specified; using all %d template(s) from '%s'",
+                len(repo_names),
+                source_org,
+            )
+
+        if self.dry_run:
+            logger.info(
+                "[dry-run] Would fork %d repo(s) from '%s' → '%s'",
+                len(repo_names),
+                source_org,
+                target_org,
+            )
+            result = CloneResult(total=len(repo_names))
+            return result
+
+        return self._template_manager.clone_templates(
+            source_org=source_org,
+            target_org=target_org,
+            repo_names=repo_names,
+        )

--- a/classdock/services/organization_service.py
+++ b/classdock/services/organization_service.py
@@ -133,8 +133,8 @@ class OrganizationService:
         if not repo_names:
             templates = self._template_manager.list_org_templates(source_org)
             repo_names = [t.name for t in templates]
-            logger.info(
-                "No repos specified; using all %d template(s) from '%s'",
+            logger.debug(
+                "No repos specified; resolved %d template(s) from '%s'",
                 len(repo_names),
                 source_org,
             )

--- a/classdock/utils/github_api_client.py
+++ b/classdock/utils/github_api_client.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Optional, Tuple
 
 import requests
 
+from .github_exceptions import RepoAlreadyExistsError
+
 logger = logging.getLogger(__name__)
 
 
@@ -679,6 +681,18 @@ class GitHubAPIClient:
                     target_owner, new_name, template_owner, template_repo,
                 )
                 return response.json()
+            if response.status_code == 422:
+                body = response.text
+                if "already exists" in body.lower():
+                    logger.debug(
+                        "'%s/%s' already exists in '%s'; skipping.",
+                        target_owner, new_name, target_owner,
+                    )
+                    raise RepoAlreadyExistsError(
+                        f"'{target_owner}/{new_name}' already exists",
+                        repository_name=new_name,
+                        operation="create_from_template",
+                    )
             logger.error(
                 "create_from_template failed for '%s/%s' → '%s/%s': HTTP %s %s",
                 template_owner, template_repo,
@@ -687,6 +701,8 @@ class GitHubAPIClient:
                 response.text[:300],
             )
             return None
+        except RepoAlreadyExistsError:
+            raise
         except Exception as exc:
             logger.error(
                 "Error creating '%s/%s' from template '%s/%s': %s",

--- a/classdock/utils/github_api_client.py
+++ b/classdock/utils/github_api_client.py
@@ -452,6 +452,290 @@ class GitHubAPIClient:
 
         return ""
 
+    # ------------------------------------------------------------------
+    # Organization management helpers
+    # ------------------------------------------------------------------
+
+    def list_user_organizations(self) -> List[Dict]:
+        """
+        List GitHub organizations the authenticated user belongs to.
+
+        Returns:
+            List of organization dicts with at minimum 'login', 'id', and 'url' keys.
+        """
+        orgs = []
+        page = 1
+        while True:
+            try:
+                response = requests.get(
+                    f"{self.base_url}/user/orgs",
+                    headers=self.headers,
+                    params={"per_page": 100, "page": page},
+                    timeout=30,
+                )
+                if response.status_code != 200:
+                    logger.error(
+                        "Failed to list user orgs: %s %s",
+                        response.status_code,
+                        response.text[:200],
+                    )
+                    break
+                page_data = response.json()
+                if not page_data:
+                    break
+                orgs.extend(page_data)
+                page += 1
+                if len(page_data) < 100:
+                    break
+            except Exception as exc:
+                logger.error("Error fetching user organizations: %s", exc)
+                break
+        return orgs
+
+    def get_organization(self, org_login: str) -> Optional[Dict]:
+        """
+        Fetch a single organization's details.
+
+        Args:
+            org_login: Organization login (slug).
+
+        Returns:
+            Organization dict, or None if not found / inaccessible.
+        """
+        try:
+            response = requests.get(
+                f"{self.base_url}/orgs/{org_login}",
+                headers=self.headers,
+                timeout=30,
+            )
+            if response.status_code == 404:
+                return None
+            if response.status_code != 200:
+                logger.error(
+                    "Failed to fetch org '%s': %s", org_login, response.status_code
+                )
+                return None
+            return response.json()
+        except Exception as exc:
+            logger.error("Error fetching organization '%s': %s", org_login, exc)
+            return None
+
+    def organization_exists(self, org_login: str) -> bool:
+        """Return True if the organization exists on GitHub."""
+        return self.get_organization(org_login) is not None
+
+    def list_org_repos(
+        self,
+        org_login: str,
+        repo_type: str = "all",
+        templates_only: bool = False,
+    ) -> List[Dict]:
+        """
+        List repositories in a GitHub organization.
+
+        Args:
+            org_login: Organization login.
+            repo_type: 'all', 'public', 'private', 'forks', or 'sources'.
+            templates_only: If True, return only repos marked as templates.
+
+        Returns:
+            List of repository dicts.
+        """
+        repos = []
+        page = 1
+        while True:
+            try:
+                response = requests.get(
+                    f"{self.base_url}/orgs/{org_login}/repos",
+                    headers=self.headers,
+                    params={"type": repo_type, "per_page": 100, "page": page},
+                    timeout=30,
+                )
+                if response.status_code != 200:
+                    logger.error(
+                        "Failed to list repos for '%s': %s %s",
+                        org_login,
+                        response.status_code,
+                        response.text[:200],
+                    )
+                    break
+                page_data = response.json()
+                if not page_data:
+                    break
+                repos.extend(page_data)
+                page += 1
+                if len(page_data) < 100:
+                    break
+            except Exception as exc:
+                logger.error("Error listing repos for org '%s': %s", org_login, exc)
+                break
+
+        if templates_only:
+            repos = [r for r in repos if r.get("is_template", False)]
+        return repos
+
+    def fork_repository(
+        self,
+        owner: str,
+        repo: str,
+        target_org: str,
+        new_name: Optional[str] = None,
+    ) -> Optional[Dict]:
+        """
+        Fork a repository into a target organization.
+
+        Uses ``POST /repos/{owner}/{repo}/forks``.
+
+        Args:
+            owner: Source repository owner (org or user login).
+            repo: Source repository name.
+            target_org: Organization login to fork into.
+            new_name: Optional new name for the forked repository.
+
+        Returns:
+            Dict with the forked repository data, or None on failure.
+        """
+        payload: Dict = {"organization": target_org}
+        if new_name:
+            payload["name"] = new_name
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/repos/{owner}/{repo}/forks",
+                headers=self.headers,
+                json=payload,
+                timeout=60,
+            )
+            if response.status_code in (202, 200):
+                logger.info(
+                    "Forked '%s/%s' into '%s'", owner, repo, target_org
+                )
+                return response.json()
+            logger.error(
+                "Fork failed for '%s/%s' → '%s': HTTP %s %s",
+                owner,
+                repo,
+                target_org,
+                response.status_code,
+                response.text[:300],
+            )
+            return None
+        except Exception as exc:
+            logger.error(
+                "Error forking '%s/%s' into '%s': %s", owner, repo, target_org, exc
+            )
+            return None
+
+    def create_from_template(
+        self,
+        template_owner: str,
+        template_repo: str,
+        target_owner: str,
+        new_name: str,
+        private: bool = True,
+        description: Optional[str] = None,
+        include_all_branches: bool = False,
+    ) -> Optional[Dict]:
+        """
+        Create a new repository from a GitHub template repository.
+
+        Uses ``POST /repos/{template_owner}/{template_repo}/generate``.
+        This is the correct approach for template repos — it works even when
+        forking is disabled, and creates a clean copy with no fork relationship.
+
+        Args:
+            template_owner: Owner of the template repository.
+            template_repo: Name of the template repository.
+            target_owner: Organization or user that will own the new repo.
+            new_name: Name for the newly created repository.
+            private: Whether the new repository should be private.
+            description: Optional repository description.
+            include_all_branches: If True, copy all branches (not just default).
+
+        Returns:
+            Dict with the new repository data, or None on failure.
+        """
+        payload: Dict = {
+            "owner": target_owner,
+            "name": new_name,
+            "private": private,
+            "include_all_branches": include_all_branches,
+        }
+        if description:
+            payload["description"] = description
+
+        headers = {**self.headers, "Accept": "application/vnd.github+json"}
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/repos/{template_owner}/{template_repo}/generate",
+                headers=headers,
+                json=payload,
+                timeout=60,
+            )
+            if response.status_code in (201, 200):
+                logger.info(
+                    "Created '%s/%s' from template '%s/%s'",
+                    target_owner, new_name, template_owner, template_repo,
+                )
+                return response.json()
+            logger.error(
+                "create_from_template failed for '%s/%s' → '%s/%s': HTTP %s %s",
+                template_owner, template_repo,
+                target_owner, new_name,
+                response.status_code,
+                response.text[:300],
+            )
+            return None
+        except Exception as exc:
+            logger.error(
+                "Error creating '%s/%s' from template '%s/%s': %s",
+                target_owner, new_name, template_owner, template_repo, exc,
+            )
+            return None
+
+    def set_repository_template(
+        self, owner: str, repo: str, is_template: bool = True
+    ) -> bool:
+        """
+        Set or clear the ``is_template`` flag on a repository.
+
+        Uses ``PATCH /repos/{owner}/{repo}``.
+
+        Args:
+            owner: Repository owner.
+            repo: Repository name.
+            is_template: True to mark as template, False to clear.
+
+        Returns:
+            True if the update succeeded, False otherwise.
+        """
+        try:
+            response = requests.patch(
+                f"{self.base_url}/repos/{owner}/{repo}",
+                headers=self.headers,
+                json={"is_template": is_template},
+                timeout=30,
+            )
+            if response.status_code == 200:
+                logger.info(
+                    "Set is_template=%s on '%s/%s'", is_template, owner, repo
+                )
+                return True
+            logger.error(
+                "Failed to set is_template on '%s/%s': HTTP %s %s",
+                owner,
+                repo,
+                response.status_code,
+                response.text[:300],
+            )
+            return False
+        except Exception as exc:
+            logger.error(
+                "Error setting template flag on '%s/%s': %s", owner, repo, exc
+            )
+            return False
+
     def _get_assignment_template_repo(self, assignment_id: int) -> str:
         """
         Get the template repository for an assignment.

--- a/classdock/utils/github_classroom_api.py
+++ b/classdock/utils/github_classroom_api.py
@@ -350,6 +350,130 @@ class GitHubClassroomAPI:
         logger.info(f"Found {len(repositories)} student repositories")
         return repositories
 
+    def get_classroom(self, classroom_id: int) -> Dict:
+        """
+        Get a specific classroom by ID.
+
+        Args:
+            classroom_id: GitHub Classroom ID
+
+        Returns:
+            Classroom dictionary
+        """
+        response = self._make_request("GET", f"/classrooms/{classroom_id}")
+        return response.json()
+
+    def get_assignment(self, assignment_id: int) -> Dict:
+        """
+        Get a specific assignment by ID.
+
+        Args:
+            assignment_id: GitHub Classroom assignment ID
+
+        Returns:
+            Assignment dictionary
+        """
+        response = self._make_request("GET", f"/assignments/{assignment_id}")
+        return response.json()
+
+    def get_assignment_grades(self, assignment_id: int) -> List[Dict]:
+        """
+        Get grading data for a specific assignment.
+
+        Args:
+            assignment_id: GitHub Classroom assignment ID
+
+        Returns:
+            List of grade records
+        """
+        response = self._make_request("GET", f"/assignments/{assignment_id}/grades")
+        return response.json()
+
+    def get_classrooms_paginated(self, per_page: int = 100) -> List[Dict]:
+        """
+        Get all classrooms with pagination support.
+
+        Args:
+            per_page: Results per page (max 100)
+
+        Returns:
+            Full list of all classroom dicts across all pages
+        """
+        results = []
+        page = 1
+        while True:
+            response = self._make_request(
+                "GET", "/classrooms", params={"page": page, "per_page": per_page}
+            )
+            page_data = response.json()
+            if not page_data:
+                break
+            results.extend(page_data)
+            if len(page_data) < per_page:
+                break
+            page += 1
+        return results
+
+    def get_classroom_assignments_paginated(
+        self, classroom_id: int, per_page: int = 100
+    ) -> List[Dict]:
+        """
+        Get all assignments for a classroom with pagination support.
+
+        Args:
+            classroom_id: GitHub Classroom ID
+            per_page: Results per page (max 100)
+
+        Returns:
+            Full list of all assignment dicts across all pages
+        """
+        results = []
+        page = 1
+        while True:
+            response = self._make_request(
+                "GET",
+                f"/classrooms/{classroom_id}/assignments",
+                params={"page": page, "per_page": per_page},
+            )
+            page_data = response.json()
+            if not page_data:
+                break
+            results.extend(page_data)
+            if len(page_data) < per_page:
+                break
+            page += 1
+        return results
+
+    def get_accepted_assignments_paginated(
+        self, assignment_id: int, per_page: int = 100
+    ) -> List[Dict]:
+        """
+        Get all accepted assignments (student repos) with pagination support.
+
+        Args:
+            assignment_id: GitHub Classroom assignment ID
+            per_page: Results per page (max 100)
+
+        Returns:
+            Full list of accepted assignment dicts across all pages
+        """
+        results = []
+        page = 1
+        while True:
+            response = self._make_request(
+                "GET",
+                f"/assignments/{assignment_id}/accepted_assignments",
+                params={"page": page, "per_page": per_page},
+            )
+            page_data = response.json()
+            if not page_data:
+                break
+            results.extend(page_data)
+            if len(page_data) < per_page:
+                break
+            page += 1
+        return results
+
     def get_assignment_metadata(
         self, classroom_url: str, github_organization: str
     ) -> Dict:

--- a/classdock/utils/github_exceptions.py
+++ b/classdock/utils/github_exceptions.py
@@ -180,6 +180,16 @@ class GitHubRepositoryError(GitHubAPIError):
         self.operation = operation
 
 
+class RepoAlreadyExistsError(GitHubRepositoryError):
+    """
+    Raised when a repository already exists in the target organization.
+
+    Signals an idempotent condition (HTTP 422 "Name already exists on this
+    account") rather than a hard failure, allowing callers to skip the repo
+    and report it as "already existed" instead of an error.
+    """
+
+
 class GitHubNetworkError(GitHubAPIError):
     """
     Raised when network-related GitHub API operations fail.

--- a/classdock/utils/github_graphql_client.py
+++ b/classdock/utils/github_graphql_client.py
@@ -1,0 +1,237 @@
+"""
+GitHub GraphQL API Client.
+
+Provides a thin wrapper around GitHub's GraphQL endpoint
+(https://api.github.com/graphql) for operations not available
+via the REST API — primarily organization creation.
+
+Note:
+    Organization creation via GraphQL requires the `admin:org` token scope.
+    Personal access tokens must include this scope. If the mutation fails
+    with a permission error, the wizard will fall back to manual guidance.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+from .github_exceptions import GitHubAPIError, GitHubAuthenticationError
+
+logger = logging.getLogger(__name__)
+
+GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+
+# GraphQL mutation for creating a GitHub organization.
+# Requires admin:org scope on the authenticated token.
+_CREATE_ORG_MUTATION = """
+mutation CreateOrganization($login: String!, $adminLogins: [String!]!, $billingEmail: String!) {
+  createOrganization(input: {
+    login: $login
+    adminLogins: $adminLogins
+    billingEmail: $billingEmail
+  }) {
+    organization {
+      id
+      login
+      name
+      url
+    }
+  }
+}
+"""
+
+_VIEWER_SCOPES_QUERY = """
+query ViewerScopes {
+  viewer {
+    login
+  }
+}
+"""
+
+
+class GitHubGraphQLClient:
+    """
+    Minimal GraphQL client for the GitHub API.
+
+    Only used for mutations/queries not available in the REST API.
+    For standard operations (repo listing, forking, etc.) prefer
+    the REST-based GitHubAPIClient.
+    """
+
+    def __init__(self, token: Optional[str] = None):
+        """
+        Initialize the client.
+
+        Args:
+            token: GitHub personal access token. Falls back to
+                   the GITHUB_TOKEN environment variable.
+
+        Raises:
+            ValueError: If no token is provided or found in environment.
+        """
+        self.token = token or os.getenv("GITHUB_TOKEN")
+        if not self.token:
+            raise ValueError(
+                "GitHub token is required. "
+                "Set the GITHUB_TOKEN environment variable or pass token= explicitly."
+            )
+
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "classdock",
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Core request
+    # ------------------------------------------------------------------
+
+    def execute(
+        self,
+        query: str,
+        variables: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Execute a GraphQL query or mutation against GitHub's API.
+
+        Args:
+            query: GraphQL query/mutation string
+            variables: Optional variables dict
+
+        Returns:
+            Parsed JSON response (the ``data`` key from the GraphQL response)
+
+        Raises:
+            GitHubAuthenticationError: On 401 / missing scope errors
+            GitHubAPIError: On non-200 HTTP status or GraphQL errors
+        """
+        payload: Dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = variables
+
+        try:
+            response = self._session.post(GRAPHQL_ENDPOINT, json=payload, timeout=30)
+        except requests.exceptions.ConnectionError as exc:
+            raise GitHubAPIError(f"Network error connecting to GitHub GraphQL: {exc}") from exc
+        except requests.exceptions.Timeout as exc:
+            raise GitHubAPIError("GitHub GraphQL request timed out.") from exc
+
+        if response.status_code == 401:
+            raise GitHubAuthenticationError(
+                "GitHub token is invalid or expired. "
+                "Run `classdock config token` to update your token."
+            )
+
+        if response.status_code != 200:
+            raise GitHubAPIError(
+                f"GitHub GraphQL returned HTTP {response.status_code}: {response.text[:300]}"
+            )
+
+        body = response.json()
+
+        if "errors" in body:
+            errors = body["errors"]
+            messages = "; ".join(e.get("message", str(e)) for e in errors)
+            # Surface scope/permission errors distinctly
+            if any("insufficient" in e.get("message", "").lower() for e in errors):
+                raise GitHubAuthenticationError(
+                    f"Insufficient token scopes for this operation. "
+                    f"Ensure your token includes 'admin:org'. Details: {messages}"
+                )
+            raise GitHubAPIError(f"GitHub GraphQL errors: {messages}")
+
+        return body.get("data", {})
+
+    # ------------------------------------------------------------------
+    # Organization operations
+    # ------------------------------------------------------------------
+
+    def create_organization(
+        self,
+        login: str,
+        billing_email: str,
+        admin_login: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create a new GitHub organization.
+
+        Args:
+            login: The organization login/slug (e.g., SOC-CS3030-Valle-SU26)
+            billing_email: Billing contact email for the organization
+            admin_login: GitHub username to add as admin. Defaults to the
+                         authenticated user's login (fetched automatically).
+
+        Returns:
+            Dict with organization fields: id, login, name, url
+
+        Raises:
+            GitHubAuthenticationError: If the token lacks ``admin:org`` scope
+            GitHubAPIError: On API errors
+        """
+        if admin_login is None:
+            admin_login = self._get_viewer_login()
+
+        logger.debug("Creating GitHub organization '%s' via GraphQL", login)
+
+        data = self.execute(
+            _CREATE_ORG_MUTATION,
+            variables={
+                "login": login,
+                "adminLogins": [admin_login],
+                "billingEmail": billing_email,
+            },
+        )
+
+        org_data = data.get("createOrganization", {}).get("organization", {})
+        if not org_data:
+            raise GitHubAPIError(
+                f"Organization creation returned empty response. "
+                f"The organization may have been created — verify at https://github.com/{login}"
+            )
+
+        logger.info("Organization '%s' created successfully", login)
+        return org_data
+
+    # ------------------------------------------------------------------
+    # Token / viewer helpers
+    # ------------------------------------------------------------------
+
+    def get_token_scopes(self) -> list:
+        """
+        Return the OAuth scopes granted to the current token.
+
+        GitHub returns the ``X-OAuth-Scopes`` header on any API response.
+        We issue a lightweight REST HEAD request rather than a GraphQL query
+        because the scopes header is only present on REST responses.
+
+        Returns:
+            List of scope strings (e.g., ['repo', 'read:org', 'admin:org'])
+        """
+        try:
+            resp = self._session.head(
+                "https://api.github.com/user",
+                headers={"Authorization": f"bearer {self.token}"},
+                timeout=10,
+            )
+            scopes_header = resp.headers.get("X-OAuth-Scopes", "")
+            return [s.strip() for s in scopes_header.split(",") if s.strip()]
+        except requests.exceptions.RequestException as exc:
+            logger.warning("Could not fetch token scopes: %s", exc)
+            return []
+
+    def has_scope(self, scope: str) -> bool:
+        """Check whether the current token has a specific OAuth scope."""
+        return scope in self.get_token_scopes()
+
+    def _get_viewer_login(self) -> str:
+        """Fetch the authenticated user's GitHub login."""
+        data = self.execute(_VIEWER_SCOPES_QUERY)
+        login = data.get("viewer", {}).get("login", "")
+        if not login:
+            raise GitHubAPIError("Could not determine authenticated user's GitHub login.")
+        return login

--- a/classdock/utils/paths.py
+++ b/classdock/utils/paths.py
@@ -137,3 +137,70 @@ class PathManager:
         except ValueError:
             # If file is not under workspace root, return absolute path
             return str(file_path.resolve())
+
+    # ------------------------------------------------------------------
+    # Organization workspace helpers
+    # ------------------------------------------------------------------
+
+    _MASTER_MARKER = ".classdock-master"
+
+    def find_master_folder(self, start: Optional[Path] = None) -> Optional[Path]:
+        """
+        Walk up the directory tree looking for a ClassDock master template folder.
+
+        A master folder is identified by the presence of a ``.classdock-master``
+        marker file in the directory.
+
+        Args:
+            start: Directory to start searching from. Defaults to self.base_path.
+
+        Returns:
+            Path to the master folder if found, otherwise None.
+        """
+        current = (start or self.base_path).resolve()
+
+        while current != current.parent:
+            if (current / self._MASTER_MARKER).exists():
+                logger.debug("Found master template folder: %s", current)
+                return current
+            current = current.parent
+
+        logger.debug("No master template folder found (no %s marker)", self._MASTER_MARKER)
+        return None
+
+    def get_org_folder(self, base: Path, org_name: str) -> Path:
+        """
+        Return the expected path for a semester org folder.
+
+        Args:
+            base: Base directory that contains all course/org folders.
+            org_name: GitHub organization name (e.g., SOC-CS3030-Valle-SU26).
+
+        Returns:
+            Path pointing to ``<base>/<org_name>``.
+        """
+        return base / org_name
+
+    def ensure_org_folder(self, base: Path, org_name: str) -> Path:
+        """
+        Create a semester org folder and write a metadata marker file.
+
+        The folder ``<base>/<org_name>`` is created (including any missing
+        parents).  A ``.classdock-org`` marker file is written into it with
+        the org name so the folder can be identified later.
+
+        Args:
+            base: Base directory that contains all course/org folders.
+            org_name: GitHub organization name.
+
+        Returns:
+            Path to the newly created org folder.
+        """
+        org_path = self.get_org_folder(base, org_name)
+        org_path.mkdir(parents=True, exist_ok=True)
+
+        marker = org_path / ".classdock-org"
+        marker.write_text(org_name, encoding="utf-8")
+
+        logger.debug("Created org folder: %s", org_path)
+        return org_path

--- a/docs/ORGANIZATION_SETUP.md
+++ b/docs/ORGANIZATION_SETUP.md
@@ -1,0 +1,232 @@
+# Organization Setup Guide
+
+ClassDock manages GitHub Classroom assignments at the **organization level**.
+Each course has a **master template folder** containing canonical assignment repositories,
+and each semester creates a new **semester org folder** linked to a GitHub organization.
+
+---
+
+## Local Workspace Structure
+
+```
+~/courses/                               # configurable base directory
+├── CS3030/                              # master template folder (one per course)
+│   ├── .classdock-master               # marker file (contains course code)
+│   ├── python-basics/                   # local git clone of template repo
+│   ├── midterm-project/
+│   └── final-project/
+└── SOC-CS3030-Valle-SU26/              # semester org folder (one per semester)
+    ├── .classdock-org                  # marker file (contains org name)
+    ├── assignment.conf                  # generated ClassDock configuration
+    ├── python-basics/                   # cloned from master
+    ├── midterm-project/
+    └── final-project/
+```
+
+---
+
+## Naming Convention
+
+GitHub organizations must follow this format:
+
+```
+[SUBJECT]-[COURSE][-SECTION]-[LASTNAME]-[SEMESTER][YEAR]
+```
+
+| Component | Rules | Example |
+|-----------|-------|---------|
+| SUBJECT | 3–4 uppercase letters | `SOC`, `WEB`, `CYBR` |
+| COURSE | Uppercase letters + 4-digit number | `CS3030`, `WEB1400` |
+| SECTION | Optional single digit | `2` (omit if only one section) |
+| LASTNAME | Capitalized last name | `Valle`, `Smith` |
+| SEMESTER | `FA` / `SP` / `SU` + 2-digit year | `SU26`, `FA25` |
+
+**Valid examples:**
+- `SOC-CS3030-Valle-SU26` (single section)
+- `SOC-CS3550-2-Smith-SP26` (section 2)
+- `SOC-WEB1400-Valle-FA25`
+
+---
+
+## Quick Start
+
+### Step 1 — Set Up Your Master Template Folder
+
+Clone your assignment template repositories into a course folder and initialize it:
+
+```bash
+mkdir ~/courses/CS3030
+cd ~/courses/CS3030
+
+# Clone your template repos
+git clone https://github.com/YOUR-ORG/python-basics
+git clone https://github.com/YOUR-ORG/midterm-project
+
+# Mark as master folder
+touch .classdock-master  # or let the wizard do this automatically
+```
+
+### Step 2 — Run the Setup Wizard
+
+```bash
+cd ~/courses/CS3030
+classdock organizations init
+```
+
+The wizard will:
+1. Verify your GitHub token has the required scopes (`repo`, `admin:org`)
+2. Detect the master template folder
+3. Let you select which templates to carry forward
+4. Build and validate the new organization name
+5. Create the local semester org folder
+6. Clone selected templates locally
+7. Create the GitHub organization
+8. Fork templates to the new GitHub org (marking them as GitHub templates)
+9. Guide you through GitHub Classroom setup
+
+### Step 3 — Complete GitHub Classroom Setup
+
+The GitHub Classroom API does not support classroom creation.
+After the wizard completes:
+
+1. Go to [classroom.github.com/classrooms/new](https://classroom.github.com/classrooms/new)
+2. Select your new organization (e.g., `SOC-CS3030-Valle-SU26`)
+3. Name your classroom (e.g., "CS3030 Summer 2026")
+4. Create assignments using the template repos now in your org
+
+### Step 4 — Configure and Run Assignments
+
+```bash
+cd ~/courses/SOC-CS3030-Valle-SU26
+classdock assignments setup    # configure the first assignment
+classdock assignments orchestrate  # run the full workflow
+```
+
+---
+
+## CLI Commands
+
+### Interactive Wizard
+
+```bash
+classdock organizations init
+classdock organizations init --dry-run   # preview without making changes
+```
+
+### Create Organization (Non-Interactive)
+
+```bash
+classdock organizations create \
+    --login SOC-CS3030-Valle-SU26 \
+    --email instructor@weber.edu \
+    --name "CS3030 Summer 2026"
+```
+
+Requires the `admin:org` scope on your GitHub token.
+
+### Clone Templates Between Organizations
+
+```bash
+# Clone all template repos from a source org
+classdock organizations clone-templates \
+    --source-org CS3030 \
+    --target-org SOC-CS3030-Valle-SU26
+
+# Clone specific repos only
+classdock organizations clone-templates \
+    --source-org CS3030 \
+    --target-org SOC-CS3030-Valle-SU26 \
+    --repos python-basics \
+    --repos midterm-project
+```
+
+### List Your GitHub Organizations
+
+```bash
+classdock organizations list
+```
+
+### Verify an Organization
+
+```bash
+classdock organizations verify SOC-CS3030-Valle-SU26
+```
+
+---
+
+## GitHub Token Requirements
+
+Your GitHub Personal Access Token must include:
+
+| Scope | Purpose |
+|-------|---------|
+| `repo` | Repository access (cloning, forking) |
+| `read:org` | List organization membership |
+| `admin:org` | Create new organizations |
+
+To update your token:
+
+```bash
+classdock config token <NEW_TOKEN>
+```
+
+Or set the environment variable:
+
+```bash
+export GITHUB_TOKEN=<YOUR_TOKEN>
+```
+
+---
+
+## Typical Semester Workflow
+
+```bash
+# At the start of each new semester:
+
+# 1. Run the organization setup wizard
+classdock organizations init
+#    → Creates SOC-CS3030-Valle-SU26/ locally and on GitHub
+
+# 2. Complete GitHub Classroom setup (manual)
+#    → Visit classroom.github.com and create classroom
+
+# 3. Set up individual assignments
+cd ~/courses/SOC-CS3030-Valle-SU26
+classdock assignments setup   # one per assignment
+
+# 4. Run the assignment workflow
+classdock assignments orchestrate
+
+# 5. Repeat steps 3–4 for each assignment
+```
+
+---
+
+## Troubleshooting
+
+### "Token is missing the 'admin:org' scope"
+
+1. Visit [github.com/settings/tokens](https://github.com/settings/tokens)
+2. Select your ClassDock token
+3. Enable the `admin:org` scope
+4. Regenerate and update: `classdock config token <NEW_TOKEN>`
+
+### "Organization already exists on GitHub"
+
+The wizard will ask whether to use the existing organization.
+Select "Yes" to continue setup with the existing org.
+
+### "No git repos found in master folder"
+
+Clone your template repositories into the master folder first:
+
+```bash
+cd ~/courses/CS3030
+git clone https://github.com/YOUR-ORG/python-basics
+```
+
+### Fork fails for a specific repo
+
+- The source repo must be accessible to your token.
+- Private repos require `repo` scope.
+- The target org must already exist before forking.

--- a/docs/ORGANIZATION_SETUP.md
+++ b/docs/ORGANIZATION_SETUP.md
@@ -87,12 +87,32 @@ The wizard will:
 ### Step 3 — Complete GitHub Classroom Setup
 
 The GitHub Classroom API does not support classroom creation.
-After the wizard completes:
+After the wizard completes it will check whether your source org already has a classroom.
+If it does, you will be offered a generated assignment checklist with one-click creation links.
+
+**Option A — Wizard detects a source classroom (automatic checklist)**
+
+The wizard prompts:
+```
+Found classroom "CS3030-Valle-S26-classroom" in source org CS3030-Valle-S26.
+Generate assignment checklist from this classroom? [Y/n]:
+```
+
+Accepting generates:
+- A per-assignment table with deep-link URLs to create each assignment
+- A `classroom_setup.md` file in your org folder with the same checklist in Markdown
+
+**Option B — No source classroom found (manual guidance)**
 
 1. Go to [classroom.github.com/classrooms/new](https://classroom.github.com/classrooms/new)
 2. Select your new organization (e.g., `SOC-CS3030-Valle-SU26`)
 3. Name your classroom (e.g., "CS3030 Summer 2026")
 4. Create assignments using the template repos now in your org
+
+You can also generate a checklist later:
+```bash
+classdock organizations classroom clone <SOURCE_CLASSROOM_ID> SOC-CS3030-Valle-SU26
+```
 
 ### Step 4 — Configure and Run Assignments
 
@@ -129,16 +149,36 @@ Requires the `admin:org` scope on your GitHub token.
 ```bash
 # Clone all template repos from a source org
 classdock organizations clone-templates \
-    --source-org CS3030 \
+    --source-org CS3030-master \
     --target-org SOC-CS3030-Valle-SU26
 
 # Clone specific repos only
 classdock organizations clone-templates \
-    --source-org CS3030 \
+    --source-org CS3030-master \
     --target-org SOC-CS3030-Valle-SU26 \
     --repos python-basics \
     --repos midterm-project
 ```
+
+The output is a per-repo status table:
+
+```
+     Clone: CS3030-master → SOC-CS3030-Valle-SU26
+┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Repository        ┃  Status  ┃
+┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ project1-template │ ✓ cloned │
+│ project2-template │ ↩ exists │
+└───────────────────┴──────────┘
+
+Summary: 1 cloned · 1 already existed
+```
+
+| Status | Meaning |
+|--------|---------|
+| `✓ cloned` | Newly created in the target org |
+| `↩ exists` | Already present — skipped (idempotent) |
+| `✗ failed` | Could not be cloned — check token/permissions |
 
 ### List Your GitHub Organizations
 
@@ -151,6 +191,109 @@ classdock organizations list
 ```bash
 classdock organizations verify SOC-CS3030-Valle-SU26
 ```
+
+Displays org details, total repo count, template repo count, and a per-repo table.
+
+---
+
+## GitHub Classroom Commands
+
+All GitHub Classroom API operations are **read-only** — classroom and assignment
+creation must be done via the web UI.  ClassDock provides inspection tools and
+generates deep-link creation URLs.
+
+### List Classrooms
+
+```bash
+# All classrooms you administer
+classdock organizations classroom list
+
+# Filtered to a specific organization
+classdock organizations classroom list SOC-CS3030-Valle-SU26
+```
+
+Output includes classroom name, linked organization, archived status, and URL.
+
+### Browse Assignments (3-level drill-down)
+
+```bash
+# All classrooms
+classdock organizations classroom assignments
+
+# Filtered by org (fewer choices in the first menu)
+classdock organizations classroom assignments SOC-CS3030-Valle-SU26
+```
+
+The command presents three interactive menus in sequence:
+
+```
+Classrooms in 'SOC-CS3030-Valle-SU26':
+
+  1. CS3030-Valle-SU26-classroom  (SOC-CS3030-Valle-SU26)
+
+Select classroom [1-1] [1]:
+
+Assignments in CS3030-Valle-SU26-classroom:
+
+  1. python-basics  individual  accepted: 28
+  2. midterm-project  individual  accepted: 25
+
+Select assignment to view student repos [1-2] [1]:
+
+       Student Repos: python-basics (CS3030-Valle-SU26-classroom)
+┏━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┓
+┃  # ┃ GitHub Username┃ Repository      ┃ Submitted ┃ Passing ┃ Commits ┃ Grade ┃
+┡━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━┩
+│  1 │ student-a      │ org/python-…    │           │    ✓    │      14 │ —     │
+```
+
+### Browse Grades (3-level drill-down)
+
+```bash
+classdock organizations classroom grades
+classdock organizations classroom grades SOC-CS3030-Valle-SU26
+```
+
+Same org → classroom → assignment selection flow, then displays:
+
+```
+       Grades: python-basics (CS3030-Valle-SU26-classroom)
+┏━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+┃  # ┃ GitHub Username┃ Points Awarded ┃ Points Available ┃ Submitted At     ┃
+┡━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
+│  1 │ student-a      │              8 │               10 │ 2026-04-01 ...   │
+```
+
+### Clone Classroom Structure into a New Org
+
+```bash
+# Get source classroom ID from: classdock organizations classroom list
+classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26
+
+# Write classroom_setup.md to a specific workspace folder
+classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26 \
+    --workspace ~/courses/SOC-CS3030-Valle-FA26
+```
+
+This command:
+1. Fetches all assignments from the source classroom
+2. Clones each starter-code repo into the target org (uses generate-from-template API)
+3. Displays a checklist table with one-click assignment creation URLs
+4. Writes `classroom_setup.md` to the workspace folder (or CWD)
+
+Example output:
+```
+    Assignment Checklist: CS3030-S26-classroom → SOC-CS3030-Valle-FA26
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Assignment    ┃ Type       ┃ Deadline   ┃ Starter  ┃ Create URL               ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ python-basics │ individual │ —          │ ✓ cloned │ https://classroom.git... │
+└───────────────┴────────────┴────────────┴──────────┴──────────────────────────┘
+```
+
+The Create URL opens GitHub Classroom's new-assignment form with the starter repo
+pre-selected.  If the target org doesn't have a classroom yet, the URL links to the
+new-classroom page instead.
 
 ---
 
@@ -181,23 +324,41 @@ export GITHUB_TOKEN=<YOUR_TOKEN>
 ## Typical Semester Workflow
 
 ```bash
-# At the start of each new semester:
+# ── NEW SEMESTER SETUP ────────────────────────────────────────────────
 
-# 1. Run the organization setup wizard
+# 1. Run the organization setup wizard from your master folder
+cd ~/courses/CS3030
 classdock organizations init
-#    → Creates SOC-CS3030-Valle-SU26/ locally and on GitHub
+#    → Wizard: select source org, pick templates, name the new org,
+#      clone locally, create GitHub org, fork templates, generate checklist
 
-# 2. Complete GitHub Classroom setup (manual)
-#    → Visit classroom.github.com and create classroom
+# 2. Verify the new org and its repos
+classdock organizations verify SOC-CS3030-Valle-FA26
 
-# 3. Set up individual assignments
-cd ~/courses/SOC-CS3030-Valle-SU26
-classdock assignments setup   # one per assignment
+# 3. (If wizard found a source classroom) Follow the generated checklist
+#    classroom_setup.md is written to ~/courses/SOC-CS3030-Valle-FA26/
 
-# 4. Run the assignment workflow
-classdock assignments orchestrate
+# 4. (If no source classroom) Clone structure from a previous semester's classroom
+classdock organizations classroom list                  # find the source classroom ID
+classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26 \
+    --workspace ~/courses/SOC-CS3030-Valle-FA26
 
-# 5. Repeat steps 3–4 for each assignment
+# 5. Create the GitHub Classroom manually (API limitation)
+#    → Visit classroom.github.com/classrooms/new, select the new org
+#    → Use the Create URLs from the checklist to add each assignment
+
+# ── MID-SEMESTER MONITORING ───────────────────────────────────────────
+
+# Check student submission progress for any assignment
+classdock organizations classroom assignments SOC-CS3030-Valle-FA26
+#    → Select classroom → select assignment → student repos table
+
+# Review grades
+classdock organizations classroom grades SOC-CS3030-Valle-FA26
+#    → Select classroom → select assignment → grades table
+
+# ── REPEAT NEXT SEMESTER ──────────────────────────────────────────────
+# Re-run classdock organizations init from the same master folder
 ```
 
 ---
@@ -225,8 +386,29 @@ cd ~/courses/CS3030
 git clone https://github.com/YOUR-ORG/python-basics
 ```
 
-### Fork fails for a specific repo
+### clone-templates shows `✗ failed` for a repo
 
 - The source repo must be accessible to your token.
-- Private repos require `repo` scope.
-- The target org must already exist before forking.
+- Private repos require the `repo` scope.
+- The target org must already exist before cloning.
+- If the source repo is a GitHub template (`is_template: true`), the
+  generate-from-template API is used automatically; otherwise forking is attempted.
+
+### "No classrooms found for 'ORG'"
+
+The GitHub Classroom list endpoint returns only classrooms where you are an admin.
+Make sure the organization is linked to a classroom at
+[classroom.github.com](https://classroom.github.com) and that your token has the
+`repo` and `read:org` scopes.
+
+### classroom grades shows 0 points for all students
+
+This is expected when GitHub Classroom autograding is not configured for the
+assignment.  Set up autograding tests in the classroom assignment settings to
+populate points data.
+
+### `classroom clone` shows "↩ exists" for all starter repos
+
+The repos were already cloned into the target org from a previous run.
+This is idempotent — the checklist and `classroom_setup.md` are still generated
+correctly using the existing repos.

--- a/tests/test_organization_classroom.py
+++ b/tests/test_organization_classroom.py
@@ -1,0 +1,215 @@
+"""
+Tests for classdock.organizations.classroom.ClassroomManager
+and the Classroom / ClassroomAssignment models.
+
+All GitHub Classroom API calls are mocked; no real network I/O occurs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from classdock.organizations.classroom import ClassroomManager
+from classdock.organizations.models import Classroom, ClassroomAssignment
+
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+_CLASSROOM_DICT = {
+    "id": 100,
+    "name": "CS3030 Summer 2026",
+    "url": "https://classroom.github.com/classrooms/100",
+    "archived": False,
+    "organization": {"login": "SOC-CS3030-Valle-SU26"},
+}
+
+_ASSIGNMENT_DICT = {
+    "id": 42,
+    "title": "python-basics",
+    "type": "individual",
+    "deadline": "2026-06-01T23:59:00Z",
+    "accepted": 15,
+    "submitted": 12,
+    "passing": 10,
+    "starter_code_repository": {"full_name": "CS3030-master/python-basics-template"},
+    "invite_link": "https://classroom.github.com/a/abc123",
+    "classroom": {"id": 100},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def manager():
+    """Return a ClassroomManager with a mocked GitHubClassroomAPI."""
+    with patch("classdock.organizations.classroom.GitHubClassroomAPI"):
+        mgr = ClassroomManager(token="fake-token")
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassroomModel:
+    def test_from_dict_basic(self):
+        c = Classroom.from_dict(_CLASSROOM_DICT)
+        assert c.id == 100
+        assert c.name == "CS3030 Summer 2026"
+        assert c.org_login == "SOC-CS3030-Valle-SU26"
+        assert c.archived is False
+
+    def test_from_dict_archived(self):
+        d = {**_CLASSROOM_DICT, "archived": True}
+        c = Classroom.from_dict(d)
+        assert c.archived is True
+
+    def test_from_dict_missing_org(self):
+        d = {**_CLASSROOM_DICT, "organization": None}
+        c = Classroom.from_dict(d)
+        assert c.org_login == ""
+
+    def test_to_dict_roundtrip(self):
+        c = Classroom.from_dict(_CLASSROOM_DICT)
+        d = c.to_dict()
+        assert d["id"] == 100
+        assert d["org_login"] == "SOC-CS3030-Valle-SU26"
+
+
+class TestClassroomAssignmentModel:
+    def test_from_dict_basic(self):
+        a = ClassroomAssignment.from_dict(_ASSIGNMENT_DICT)
+        assert a.id == 42
+        assert a.title == "python-basics"
+        assert a.type == "individual"
+        assert a.deadline == "2026-06-01T23:59:00Z"
+        assert a.accepted_count == 15
+        assert a.submitted_count == 12
+        assert a.passing_count == 10
+        assert a.starter_code_repo == "CS3030-master/python-basics-template"
+        assert a.invite_link == "https://classroom.github.com/a/abc123"
+        assert a.classroom_id == 100
+
+    def test_from_dict_no_starter_repo(self):
+        d = {**_ASSIGNMENT_DICT, "starter_code_repository": None}
+        a = ClassroomAssignment.from_dict(d)
+        assert a.starter_code_repo is None
+
+    def test_from_dict_defaults(self):
+        d = {"id": 1, "title": "hw1"}
+        a = ClassroomAssignment.from_dict(d)
+        assert a.type == "individual"
+        assert a.deadline is None
+        assert a.accepted_count == 0
+
+    def test_to_dict_roundtrip(self):
+        a = ClassroomAssignment.from_dict(_ASSIGNMENT_DICT)
+        d = a.to_dict()
+        assert d["title"] == "python-basics"
+        assert d["starter_code_repo"] == "CS3030-master/python-basics-template"
+
+
+# ---------------------------------------------------------------------------
+# ClassroomManager tests
+# ---------------------------------------------------------------------------
+
+
+class TestListClassrooms:
+    def test_returns_classroom_objects(self, manager):
+        manager._api.get_classrooms_paginated.return_value = [_CLASSROOM_DICT]
+        classrooms = manager.list_classrooms()
+        assert len(classrooms) == 1
+        assert isinstance(classrooms[0], Classroom)
+
+    def test_returns_sorted(self, manager):
+        manager._api.get_classrooms_paginated.return_value = [
+            {**_CLASSROOM_DICT, "name": "ZZZ Class"},
+            {**_CLASSROOM_DICT, "name": "AAA Class", "id": 101},
+        ]
+        classrooms = manager.list_classrooms()
+        assert classrooms[0].name == "AAA Class"
+
+    def test_empty(self, manager):
+        manager._api.get_classrooms_paginated.return_value = []
+        assert manager.list_classrooms() == []
+
+
+class TestListClassroomsForOrg:
+    def test_filters_by_org(self, manager):
+        manager._api.get_classrooms_paginated.return_value = [
+            _CLASSROOM_DICT,
+            {**_CLASSROOM_DICT, "id": 200, "organization": {"login": "other-org"}},
+        ]
+        classrooms = manager.list_classrooms_for_org("SOC-CS3030-Valle-SU26")
+        assert len(classrooms) == 1
+        assert classrooms[0].org_login == "SOC-CS3030-Valle-SU26"
+
+    def test_case_insensitive(self, manager):
+        manager._api.get_classrooms_paginated.return_value = [_CLASSROOM_DICT]
+        classrooms = manager.list_classrooms_for_org("soc-cs3030-valle-su26")
+        assert len(classrooms) == 1
+
+    def test_no_match_returns_empty(self, manager):
+        manager._api.get_classrooms_paginated.return_value = [_CLASSROOM_DICT]
+        classrooms = manager.list_classrooms_for_org("unknown-org")
+        assert classrooms == []
+
+
+class TestGetClassroom:
+    def test_returns_classroom(self, manager):
+        manager._api.get_classroom.return_value = _CLASSROOM_DICT
+        c = manager.get_classroom(100)
+        assert c is not None
+        assert c.id == 100
+
+    def test_returns_none_on_404(self, manager):
+        from classdock.utils.github_classroom_api import GitHubClassroomAPIError
+        err = GitHubClassroomAPIError("not found", status_code=404)
+        manager._api.get_classroom.side_effect = err
+        assert manager.get_classroom(999) is None
+
+
+class TestListAssignments:
+    def test_returns_assignment_objects(self, manager):
+        manager._api.get_classroom_assignments_paginated.return_value = [_ASSIGNMENT_DICT]
+        assignments = manager.list_assignments(100)
+        assert len(assignments) == 1
+        assert isinstance(assignments[0], ClassroomAssignment)
+
+    def test_empty_classroom(self, manager):
+        manager._api.get_classroom_assignments_paginated.return_value = []
+        assert manager.list_assignments(100) == []
+
+
+class TestGetAssignment:
+    def test_returns_assignment(self, manager):
+        manager._api.get_assignment.return_value = _ASSIGNMENT_DICT
+        a = manager.get_assignment(42)
+        assert a is not None
+        assert a.title == "python-basics"
+
+    def test_returns_none_on_404(self, manager):
+        from classdock.utils.github_classroom_api import GitHubClassroomAPIError
+        err = GitHubClassroomAPIError("not found", status_code=404)
+        manager._api.get_assignment.side_effect = err
+        assert manager.get_assignment(999) is None
+
+
+class TestAssignmentCreationUrl:
+    def test_without_template(self):
+        url = ClassroomManager.assignment_creation_url(100)
+        assert url == "https://classroom.github.com/classrooms/100/assignments/new"
+
+    def test_with_template(self):
+        url = ClassroomManager.assignment_creation_url(100, "myorg/my-repo")
+        assert "template_repo=myorg/my-repo" in url
+
+    def test_new_classroom_url(self):
+        url = ClassroomManager.new_classroom_url()
+        assert "classroom.github.com/classrooms/new" in url

--- a/tests/test_organization_manager.py
+++ b/tests/test_organization_manager.py
@@ -1,0 +1,117 @@
+"""
+Tests for classdock.organizations.manager.OrganizationManager.
+
+All GitHub API calls are mocked; no real network I/O occurs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from classdock.organizations.manager import OrganizationManager
+from classdock.organizations.models import Organization
+
+
+@pytest.fixture()
+def manager():
+    """Return an OrganizationManager with a stub token."""
+    with patch("classdock.organizations.manager.GitHubAPIClient"), \
+         patch("classdock.organizations.manager.GitHubGraphQLClient"):
+        mgr = OrganizationManager(token="fake-token")
+    return mgr
+
+
+class TestListUserOrganizations:
+    def test_returns_sorted_list(self, manager):
+        manager._rest.list_user_organizations.return_value = [
+            {"login": "zoo-org", "id": 2},
+            {"login": "alpha-org", "id": 1},
+        ]
+        orgs = manager.list_user_organizations()
+        assert [o.login for o in orgs] == ["alpha-org", "zoo-org"]
+
+    def test_returns_empty_when_no_orgs(self, manager):
+        manager._rest.list_user_organizations.return_value = []
+        assert manager.list_user_organizations() == []
+
+    def test_maps_to_organization_objects(self, manager):
+        manager._rest.list_user_organizations.return_value = [
+            {"login": "my-org", "id": 42, "html_url": "https://github.com/my-org"},
+        ]
+        orgs = manager.list_user_organizations()
+        assert isinstance(orgs[0], Organization)
+        assert orgs[0].login == "my-org"
+        assert orgs[0].id == 42
+
+
+class TestGetOrganization:
+    def test_returns_organization(self, manager):
+        manager._rest.get_organization.return_value = {
+            "login": "SOC-CS3030-Valle-SU26",
+            "id": 99,
+        }
+        org = manager.get_organization("SOC-CS3030-Valle-SU26")
+        assert org is not None
+        assert org.login == "SOC-CS3030-Valle-SU26"
+
+    def test_returns_none_when_not_found(self, manager):
+        manager._rest.get_organization.return_value = None
+        org = manager.get_organization("nonexistent-org")
+        assert org is None
+
+
+class TestOrganizationExists:
+    def test_true_when_exists(self, manager):
+        manager._rest.organization_exists.return_value = True
+        assert manager.organization_exists("real-org")
+
+    def test_false_when_not_exists(self, manager):
+        manager._rest.organization_exists.return_value = False
+        assert not manager.organization_exists("ghost-org")
+
+
+class TestCreateOrganization:
+    def test_raises_permission_error_when_scope_missing(self, manager):
+        manager._graphql.has_scope.return_value = False
+        manager._graphql.get_token_scopes.return_value = ["repo"]
+        with pytest.raises(PermissionError, match="admin:org"):
+            manager.create_organization(
+                "SOC-CS3030-Valle-SU26", "instructor@example.com"
+            )
+
+    def test_creates_org_when_scope_present(self, manager):
+        manager._graphql.has_scope.return_value = True
+        manager._graphql.create_organization.return_value = {
+            "login": "SOC-CS3030-Valle-SU26",
+            "name": "CS3030 Summer 2026",
+            "url": "https://github.com/SOC-CS3030-Valle-SU26",
+        }
+        org = manager.create_organization(
+            "SOC-CS3030-Valle-SU26", "instructor@example.com", display_name="CS3030"
+        )
+        assert org.login == "SOC-CS3030-Valle-SU26"
+        assert org.name == "CS3030"
+
+    def test_uses_login_as_name_fallback(self, manager):
+        manager._graphql.has_scope.return_value = True
+        manager._graphql.create_organization.return_value = {
+            "login": "SOC-CS3030-Valle-SU26",
+        }
+        org = manager.create_organization(
+            "SOC-CS3030-Valle-SU26", "instructor@example.com"
+        )
+        assert org.name == "SOC-CS3030-Valle-SU26"
+
+
+class TestTokenHelpers:
+    def test_get_token_scopes(self, manager):
+        manager._graphql.get_token_scopes.return_value = ["repo", "admin:org"]
+        assert manager.get_token_scopes() == ["repo", "admin:org"]
+
+    def test_has_required_scopes_true(self, manager):
+        manager._graphql.get_token_scopes.return_value = ["repo", "admin:org", "read:org"]
+        assert manager.has_required_scopes()
+
+    def test_has_required_scopes_false_missing_admin(self, manager):
+        manager._graphql.get_token_scopes.return_value = ["repo", "read:org"]
+        assert not manager.has_required_scopes()

--- a/tests/test_organization_models.py
+++ b/tests/test_organization_models.py
@@ -1,0 +1,174 @@
+"""
+Tests for classdock.organizations.models module.
+
+Covers Organization, TemplateRepo, WorkspaceFolder, CloneResult, SetupResult.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from classdock.organizations.models import (
+    CloneResult,
+    Organization,
+    SetupResult,
+    TemplateRepo,
+    WorkspaceFolder,
+)
+
+
+class TestOrganization:
+    """Tests for Organization model."""
+
+    def test_create_minimal(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        assert org.login == "SOC-CS3030-Valle-SU26"
+        assert org.id is None
+        assert org.name is None
+
+    def test_from_dict(self):
+        data = {
+            "login": "SOC-CS3030-Valle-SU26",
+            "name": "CS3030 Summer 2026",
+            "id": 42,
+            "description": "Test org",
+            "html_url": "https://github.com/SOC-CS3030-Valle-SU26",
+            "avatar_url": "https://example.com/avatar.png",
+            "role": "admin",
+        }
+        org = Organization.from_dict(data)
+        assert org.login == "SOC-CS3030-Valle-SU26"
+        assert org.name == "CS3030 Summer 2026"
+        assert org.id == 42
+        assert org.role == "admin"
+        assert "github.com" in org.url
+
+    def test_to_dict_roundtrip(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26", name="CS3030", id=1, role="admin")
+        d = org.to_dict()
+        assert d["login"] == "SOC-CS3030-Valle-SU26"
+        assert d["name"] == "CS3030"
+        assert d["id"] == 1
+
+
+class TestTemplateRepo:
+    """Tests for TemplateRepo model."""
+
+    def test_create_minimal(self):
+        repo = TemplateRepo(name="python-basics", owner="SOC-CS3030-Valle-SU26")
+        assert repo.full_name == "SOC-CS3030-Valle-SU26/python-basics"
+        assert not repo.is_template
+
+    def test_full_name_auto_populated(self):
+        repo = TemplateRepo(name="repo", owner="myorg")
+        assert repo.full_name == "myorg/repo"
+
+    def test_explicit_full_name_not_overwritten(self):
+        repo = TemplateRepo(name="repo", owner="myorg", full_name="myorg/repo-custom")
+        assert repo.full_name == "myorg/repo-custom"
+
+    def test_from_dict(self):
+        data = {
+            "name": "python-basics",
+            "owner": {"login": "SOC-CS3030-Valle-SU26"},
+            "full_name": "SOC-CS3030-Valle-SU26/python-basics",
+            "html_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics",
+            "clone_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics.git",
+            "is_template": True,
+            "private": False,
+            "description": "Python basics assignment",
+        }
+        repo = TemplateRepo.from_dict(data)
+        assert repo.name == "python-basics"
+        assert repo.owner == "SOC-CS3030-Valle-SU26"
+        assert repo.is_template is True
+
+    def test_to_dict(self):
+        repo = TemplateRepo(name="repo", owner="org", is_template=True)
+        d = repo.to_dict()
+        assert d["name"] == "repo"
+        assert d["is_template"] is True
+        assert d["local_path"] is None
+
+    def test_to_dict_with_local_path(self):
+        repo = TemplateRepo(name="repo", owner="org", local_path=Path("/tmp/repo"))
+        d = repo.to_dict()
+        assert d["local_path"] == "/tmp/repo"
+
+
+class TestWorkspaceFolder:
+    """Tests for WorkspaceFolder model."""
+
+    def test_create(self, tmp_path):
+        wf = WorkspaceFolder(path=tmp_path, is_master=True, course_code="CS3030")
+        assert wf.path == tmp_path
+        assert wf.is_master
+        assert wf.course_code == "CS3030"
+
+    def test_marker_path(self, tmp_path):
+        wf = WorkspaceFolder(path=tmp_path)
+        assert wf.marker_path == tmp_path / ".classdock-master"
+
+    def test_is_marked_as_master_true(self, tmp_path):
+        (tmp_path / ".classdock-master").touch()
+        wf = WorkspaceFolder(path=tmp_path)
+        assert wf.is_marked_as_master()
+
+    def test_is_marked_as_master_false(self, tmp_path):
+        wf = WorkspaceFolder(path=tmp_path)
+        assert not wf.is_marked_as_master()
+
+    def test_to_dict(self, tmp_path):
+        wf = WorkspaceFolder(path=tmp_path, is_master=True, course_code="CS3030")
+        d = wf.to_dict()
+        assert d["is_master"] is True
+        assert d["course_code"] == "CS3030"
+        assert d["repos"] == []
+
+
+class TestCloneResult:
+    """Tests for CloneResult model."""
+
+    def test_initial_state(self):
+        r = CloneResult(total=5)
+        assert r.successful == 0
+        assert r.failed == 0
+        assert r.success_rate == 0.0
+
+    def test_add_success(self):
+        r = CloneResult(total=2)
+        repo = TemplateRepo(name="repo", owner="org")
+        r.add_success(repo)
+        assert r.successful == 1
+        assert repo in r.cloned_repos
+
+    def test_add_failure(self):
+        r = CloneResult(total=2)
+        r.add_failure("API error")
+        assert r.failed == 1
+        assert "API error" in r.errors
+
+    def test_success_rate(self):
+        r = CloneResult(total=4)
+        for _ in range(3):
+            r.add_success(TemplateRepo(name="r", owner="o"))
+        assert r.success_rate == 75.0
+
+    def test_success_rate_zero_total(self):
+        r = CloneResult(total=0)
+        assert r.success_rate == 0.0
+
+
+class TestSetupResult:
+    """Tests for SetupResult model."""
+
+    def test_default_is_failure(self):
+        r = SetupResult()
+        assert not r.success
+        assert r.organization is None
+
+    def test_with_all_fields(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        r = SetupResult(organization=org, success=True)
+        assert r.success
+        assert r.organization.login == "SOC-CS3030-Valle-SU26"

--- a/tests/test_organization_paths.py
+++ b/tests/test_organization_paths.py
@@ -1,0 +1,93 @@
+"""
+Tests for organization-workspace path helpers in classdock.utils.paths.
+
+Covers PathManager.find_master_folder(), .get_org_folder(), .ensure_org_folder().
+"""
+
+import pytest
+
+from classdock.utils.paths import PathManager
+
+
+class TestFindMasterFolder:
+    """Tests for PathManager.find_master_folder()."""
+
+    def test_finds_marker_in_start_directory(self, tmp_path):
+        (tmp_path / ".classdock-master").touch()
+        pm = PathManager(tmp_path)
+        result = pm.find_master_folder(start=tmp_path)
+        assert result == tmp_path
+
+    def test_finds_marker_in_parent(self, tmp_path):
+        (tmp_path / ".classdock-master").touch()
+        child = tmp_path / "subdir"
+        child.mkdir()
+        pm = PathManager(child)
+        result = pm.find_master_folder(start=child)
+        assert result == tmp_path
+
+    def test_finds_marker_two_levels_up(self, tmp_path):
+        (tmp_path / ".classdock-master").touch()
+        deep = tmp_path / "a" / "b"
+        deep.mkdir(parents=True)
+        pm = PathManager(deep)
+        result = pm.find_master_folder(start=deep)
+        assert result == tmp_path
+
+    def test_returns_none_when_no_marker(self, tmp_path):
+        pm = PathManager(tmp_path)
+        result = pm.find_master_folder(start=tmp_path)
+        assert result is None
+
+    def test_uses_base_path_when_start_is_none(self, tmp_path):
+        (tmp_path / ".classdock-master").touch()
+        pm = PathManager(tmp_path)
+        result = pm.find_master_folder()
+        assert result == tmp_path
+
+
+class TestGetOrgFolder:
+    """Tests for PathManager.get_org_folder()."""
+
+    def test_returns_correct_path(self, tmp_path):
+        pm = PathManager(tmp_path)
+        result = pm.get_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        assert result == tmp_path / "SOC-CS3030-Valle-SU26"
+
+    def test_does_not_create_directory(self, tmp_path):
+        pm = PathManager(tmp_path)
+        result = pm.get_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        assert not result.exists()
+
+
+class TestEnsureOrgFolder:
+    """Tests for PathManager.ensure_org_folder()."""
+
+    def test_creates_directory(self, tmp_path):
+        pm = PathManager(tmp_path)
+        result = pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        assert result.is_dir()
+
+    def test_creates_marker_file(self, tmp_path):
+        pm = PathManager(tmp_path)
+        result = pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        marker = result / ".classdock-org"
+        assert marker.exists()
+        assert marker.read_text(encoding="utf-8") == "SOC-CS3030-Valle-SU26"
+
+    def test_folder_name_matches_org_name(self, tmp_path):
+        pm = PathManager(tmp_path)
+        result = pm.ensure_org_folder(tmp_path, "SOC-CS3550-2-Smith-SP26")
+        assert result.name == "SOC-CS3550-2-Smith-SP26"
+
+    def test_idempotent_when_called_twice(self, tmp_path):
+        pm = PathManager(tmp_path)
+        pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        result = pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        assert result.is_dir()
+
+    def test_creates_nested_base(self, tmp_path):
+        nested_base = tmp_path / "courses" / "2026"
+        pm = PathManager(tmp_path)
+        result = pm.ensure_org_folder(nested_base, "SOC-CS3030-Valle-SU26")
+        assert result.is_dir()

--- a/tests/test_organization_service.py
+++ b/tests/test_organization_service.py
@@ -1,0 +1,124 @@
+"""
+Tests for classdock.services.organization_service.OrganizationService.
+
+All external dependencies are mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from classdock.organizations.models import (
+    CloneResult,
+    Organization,
+    SetupResult,
+    TemplateRepo,
+)
+from classdock.services.organization_service import OrganizationService
+
+
+def _make_service(wizard_result=None, dry_run=False):
+    """Build an OrganizationService with mocked sub-managers."""
+    mock_wizard = MagicMock()
+    mock_wizard.run.return_value = wizard_result or SetupResult(success=False, error_message="err")
+
+    with patch("classdock.services.organization_service.OrganizationManager"), \
+         patch("classdock.services.organization_service.TemplateManager"):
+        svc = OrganizationService(
+            token="fake-token",
+            dry_run=dry_run,
+            wizard_factory=lambda: mock_wizard,
+        )
+    svc._mock_wizard = mock_wizard
+    return svc
+
+
+class TestSetup:
+    def test_returns_true_on_success(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        result = SetupResult(success=True, organization=org)
+        svc = _make_service(wizard_result=result)
+        ok, msg = svc.setup()
+        assert ok
+        assert "SOC-CS3030-Valle-SU26" in msg
+
+    def test_returns_false_on_failure(self):
+        result = SetupResult(success=False, error_message="No master folder selected.")
+        svc = _make_service(wizard_result=result)
+        ok, msg = svc.setup()
+        assert not ok
+        assert "No master folder" in msg
+
+    def test_handles_exception_gracefully(self):
+        mock_wizard = MagicMock()
+        mock_wizard.run.side_effect = RuntimeError("API is down")
+        with patch("classdock.services.organization_service.OrganizationManager"), \
+             patch("classdock.services.organization_service.TemplateManager"):
+            svc = OrganizationService(
+                token="fake",
+                wizard_factory=lambda: mock_wizard,
+            )
+        ok, msg = svc.setup()
+        assert not ok
+        assert "API is down" in msg
+
+
+class TestListOrganizations:
+    def test_delegates_to_org_manager(self):
+        svc = _make_service()
+        orgs = [Organization(login="org-a"), Organization(login="org-b")]
+        svc._org_manager.list_user_organizations.return_value = orgs
+        result = svc.list_organizations()
+        assert result == orgs
+
+    def test_returns_empty_list_when_none(self):
+        svc = _make_service()
+        svc._org_manager.list_user_organizations.return_value = []
+        assert svc.list_organizations() == []
+
+
+class TestVerifyOrganization:
+    def test_returns_true_and_org_when_exists(self):
+        svc = _make_service()
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        svc._org_manager.get_organization.return_value = org
+        exists, found = svc.verify_organization("SOC-CS3030-Valle-SU26")
+        assert exists
+        assert found == org
+
+    def test_returns_false_and_none_when_missing(self):
+        svc = _make_service()
+        svc._org_manager.get_organization.return_value = None
+        exists, found = svc.verify_organization("ghost-org")
+        assert not exists
+        assert found is None
+
+
+class TestCloneTemplates:
+    def test_delegates_to_template_manager(self):
+        svc = _make_service()
+        expected = CloneResult(total=2, successful=2)
+        svc._template_manager.clone_templates.return_value = expected
+
+        result = svc.clone_templates("src-org", "target-org", ["repo-a", "repo-b"])
+        assert result == expected
+        svc._template_manager.clone_templates.assert_called_once()
+
+    def test_uses_all_templates_when_no_names_given(self):
+        svc = _make_service()
+        svc._template_manager.list_org_templates.return_value = [
+            TemplateRepo(name="repo-x", owner="src-org"),
+            TemplateRepo(name="repo-y", owner="src-org"),
+        ]
+        svc._template_manager.clone_templates.return_value = CloneResult(total=2)
+
+        svc.clone_templates("src-org", "target-org", [])
+
+        call_kwargs = svc._template_manager.clone_templates.call_args[1]
+        assert set(call_kwargs["repo_names"]) == {"repo-x", "repo-y"}
+
+    def test_dry_run_skips_api_call(self):
+        svc = _make_service(dry_run=True)
+        result = svc.clone_templates("src", "tgt", ["repo-a"])
+        svc._template_manager.clone_templates.assert_not_called()
+        assert result.total == 1

--- a/tests/test_organization_templates.py
+++ b/tests/test_organization_templates.py
@@ -1,0 +1,170 @@
+"""
+Tests for classdock.organizations.templates.TemplateManager.
+
+All GitHub REST API calls are mocked; no real network I/O occurs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from classdock.organizations.models import CloneResult, TemplateRepo
+from classdock.organizations.templates import TemplateManager
+
+
+@pytest.fixture()
+def manager():
+    """Return a TemplateManager with a mocked REST client."""
+    with patch("classdock.organizations.templates.GitHubAPIClient"):
+        mgr = TemplateManager(token="fake-token")
+    return mgr
+
+
+_REPO_DICT = {
+    "name": "python-basics",
+    "owner": {"login": "SOC-CS3030-Valle-SU26"},
+    "full_name": "SOC-CS3030-Valle-SU26/python-basics",
+    "html_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics",
+    "clone_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics.git",
+    "is_template": True,
+    "private": False,
+    "description": "Python basics assignment",
+}
+
+
+class TestListOrgTemplates:
+    def test_returns_template_repos(self, manager):
+        manager._api.list_org_repos.return_value = [_REPO_DICT]
+        repos = manager.list_org_templates("SOC-CS3030-Valle-SU26")
+        assert len(repos) == 1
+        assert isinstance(repos[0], TemplateRepo)
+
+    def test_returns_sorted(self, manager):
+        manager._api.list_org_repos.return_value = [
+            {**_REPO_DICT, "name": "zzz-repo"},
+            {**_REPO_DICT, "name": "aaa-repo"},
+        ]
+        repos = manager.list_org_templates("org")
+        assert repos[0].name == "aaa-repo"
+
+    def test_empty_org(self, manager):
+        manager._api.list_org_repos.return_value = []
+        assert manager.list_org_templates("empty-org") == []
+
+
+class TestForkRepository:
+    def test_returns_template_repo_on_success(self, manager):
+        manager._api.fork_repository.return_value = _REPO_DICT
+        repo = manager.fork_repository(
+            source_owner="master-org",
+            repo_name="python-basics",
+            target_org="SOC-CS3030-Valle-SU26",
+        )
+        assert repo is not None
+        assert repo.name == "python-basics"
+
+    def test_returns_none_on_api_failure(self, manager):
+        manager._api.fork_repository.return_value = None
+        repo = manager.fork_repository("org", "repo", "target-org")
+        assert repo is None
+
+    def test_passes_new_name(self, manager):
+        manager._api.fork_repository.return_value = _REPO_DICT
+        manager.fork_repository("org", "repo", "target-org", new_name="renamed-repo")
+        manager._api.fork_repository.assert_called_once_with(
+            owner="org",
+            repo="repo",
+            target_org="target-org",
+            new_name="renamed-repo",
+        )
+
+
+class TestMakeTemplate:
+    def test_returns_true_on_success(self, manager):
+        manager._api.set_repository_template.return_value = True
+        assert manager.make_template("org", "repo") is True
+
+    def test_returns_false_on_failure(self, manager):
+        manager._api.set_repository_template.return_value = False
+        assert manager.make_template("org", "repo") is False
+
+
+class TestCloneTemplates:
+    def _setup_success(self, manager):
+        manager._api.fork_repository.return_value = _REPO_DICT
+        manager._api.set_repository_template.return_value = True
+
+    def test_all_success(self, manager):
+        self._setup_success(manager)
+        result = manager.clone_templates(
+            source_org="CS3030",
+            target_org="SOC-CS3030-Valle-SU26",
+            repo_names=["python-basics", "midterm-project"],
+            settle_seconds=0,
+        )
+        assert result.total == 2
+        assert result.successful == 2
+        assert result.failed == 0
+        assert result.success_rate == 100.0
+
+    def test_partial_failure(self, manager):
+        call_count = [0]
+
+        def template_side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return None  # first call fails
+            return _REPO_DICT
+
+        manager._api.create_from_template.side_effect = template_side_effect
+        manager._api.fork_repository.return_value = None  # fallback also fails
+        manager._api.set_repository_template.return_value = True
+
+        result = manager.clone_templates(
+            source_org="CS3030",
+            target_org="SOC-CS3030-Valle-SU26",
+            repo_names=["fail-repo", "ok-repo"],
+            settle_seconds=0,
+        )
+        assert result.successful == 1
+        assert result.failed == 1
+        assert len(result.errors) == 1
+
+    def test_progress_callback_called(self, manager):
+        self._setup_success(manager)
+        calls = []
+        manager.clone_templates(
+            source_org="CS3030",
+            target_org="target-org",
+            repo_names=["repo-a", "repo-b"],
+            progress_callback=lambda cur, total, name: calls.append((cur, total, name)),
+            settle_seconds=0,
+        )
+        assert calls == [(1, 2, "repo-a"), (2, 2, "repo-b")]
+
+    def test_empty_repo_list(self, manager):
+        result = manager.clone_templates("src", "tgt", [], settle_seconds=0)
+        assert result.total == 0
+        assert result.successful == 0
+
+    def test_sets_is_template_true_on_cloned_repos(self, manager):
+        self._setup_success(manager)
+        result = manager.clone_templates(
+            source_org="CS3030",
+            target_org="target-org",
+            repo_names=["python-basics"],
+            settle_seconds=0,
+        )
+        assert result.cloned_repos[0].is_template is True
+
+    def test_still_counts_as_success_when_template_flag_fails(self, manager):
+        manager._api.fork_repository.return_value = _REPO_DICT
+        manager._api.set_repository_template.return_value = False  # template flag fails
+        result = manager.clone_templates(
+            source_org="CS3030",
+            target_org="target-org",
+            repo_names=["python-basics"],
+            settle_seconds=0,
+        )
+        assert result.successful == 1
+        assert result.cloned_repos[0].is_template is False

--- a/tests/test_organization_validators.py
+++ b/tests/test_organization_validators.py
@@ -1,0 +1,172 @@
+"""
+Tests for classdock.organizations.validators module.
+
+Covers OrgNameValidator.validate(), .build(), and .suggest().
+"""
+
+import pytest
+
+from classdock.organizations.validators import (
+    OrgNameValidator,
+    ValidationResult,
+    VALID_SEMESTERS,
+)
+
+
+class TestValidate:
+    """Tests for OrgNameValidator.validate()."""
+
+    # --- valid names ---
+
+    def test_valid_no_section(self):
+        result = OrgNameValidator.validate("SOC-CS3030-Valle-SU26")
+        assert result.is_valid
+        assert result.error is None
+        assert result.subject == "SOC"
+        assert result.course == "CS3030"
+        assert result.section is None
+        assert result.lastname == "Valle"
+        assert result.semester == "SU"
+        assert result.year == "26"
+
+    def test_valid_with_section(self):
+        result = OrgNameValidator.validate("SOC-CS3550-2-Smith-SP26")
+        assert result.is_valid
+        assert result.section == "2"
+        assert result.lastname == "Smith"
+        assert result.semester == "SP"
+
+    def test_valid_fall_semester(self):
+        result = OrgNameValidator.validate("SOC-WEB1400-Valle-FA25")
+        assert result.is_valid
+        assert result.semester == "FA"
+        assert result.course == "WEB1400"
+
+    def test_valid_four_letter_subject(self):
+        # CYBR is a 4-letter subject (CYBER has 5, which exceeds the 3-4 letter rule)
+        result = OrgNameValidator.validate("CYBR-CS2700-Jones-FA25")
+        assert result.is_valid
+        assert result.subject == "CYBR"
+
+    def test_valid_section_1(self):
+        result = OrgNameValidator.validate("SOC-CS2810-1-Brown-SP26")
+        assert result.is_valid
+        assert result.section == "1"
+
+    # --- invalid names ---
+
+    def test_empty_string(self):
+        result = OrgNameValidator.validate("")
+        assert not result.is_valid
+        assert "empty" in result.error.lower()
+
+    def test_whitespace_only(self):
+        result = OrgNameValidator.validate("   ")
+        assert not result.is_valid
+
+    def test_lowercase_subject(self):
+        result = OrgNameValidator.validate("soc-CS3030-Valle-SU26")
+        assert not result.is_valid
+
+    def test_invalid_semester(self):
+        result = OrgNameValidator.validate("SOC-CS3030-Valle-WI26")
+        assert not result.is_valid
+
+    def test_lowercase_lastname(self):
+        result = OrgNameValidator.validate("SOC-CS3030-valle-SU26")
+        assert not result.is_valid
+
+    def test_missing_year(self):
+        result = OrgNameValidator.validate("SOC-CS3030-Valle-SU")
+        assert not result.is_valid
+
+    def test_three_digit_course(self):
+        result = OrgNameValidator.validate("SOC-CS303-Valle-SU26")
+        assert not result.is_valid
+
+    def test_no_dashes(self):
+        result = OrgNameValidator.validate("SOCCS3030ValleSU26")
+        assert not result.is_valid
+
+    def test_extra_segment(self):
+        # Too many parts that don't match pattern
+        result = OrgNameValidator.validate("SOC-CS3030-Valle-SU26-EXTRA")
+        assert not result.is_valid
+
+    def test_subject_too_long(self):
+        result = OrgNameValidator.validate("SOCIA-CS3030-Valle-SU26")
+        assert not result.is_valid
+
+    def test_subject_too_short(self):
+        result = OrgNameValidator.validate("SO-CS3030-Valle-SU26")
+        assert not result.is_valid
+
+
+class TestValidationResultProperties:
+    """Tests for ValidationResult helper properties."""
+
+    def test_semester_label_fall(self):
+        r = OrgNameValidator.validate("SOC-CS3030-Valle-FA25")
+        assert r.semester_label == "Fall"
+
+    def test_semester_label_spring(self):
+        r = OrgNameValidator.validate("SOC-CS3030-Valle-SP26")
+        assert r.semester_label == "Spring"
+
+    def test_semester_label_summer(self):
+        r = OrgNameValidator.validate("SOC-CS3030-Valle-SU26")
+        assert r.semester_label == "Summer"
+
+    def test_full_year(self):
+        r = OrgNameValidator.validate("SOC-CS3030-Valle-FA25")
+        assert r.full_year == "2025"
+
+    def test_semester_label_none_when_invalid(self):
+        r = ValidationResult(is_valid=False, error="bad")
+        assert r.semester_label is None
+        assert r.full_year is None
+
+
+class TestBuild:
+    """Tests for OrgNameValidator.build()."""
+
+    def test_build_no_section(self):
+        name = OrgNameValidator.build("SOC", "CS3030", "Valle", "SU", "26")
+        assert name == "SOC-CS3030-Valle-SU26"
+
+    def test_build_with_section(self):
+        name = OrgNameValidator.build("SOC", "CS3550", "Smith", "SP", "26", section="2")
+        assert name == "SOC-CS3550-2-Smith-SP26"
+
+    def test_build_normalizes_case(self):
+        name = OrgNameValidator.build("soc", "cs3030", "valle", "su", "26")
+        assert name == "SOC-CS3030-Valle-SU26"
+
+    def test_build_invalid_raises(self):
+        with pytest.raises(ValueError, match="invalid"):
+            OrgNameValidator.build("SO", "CS3030", "Valle", "SU", "26")  # subject too short
+
+
+class TestSuggest:
+    """Tests for OrgNameValidator.suggest()."""
+
+    def test_suggest_basic(self):
+        name = OrgNameValidator.suggest("SOC", "CS3030", "Valle", "SU", "26")
+        assert name == "SOC-CS3030-Valle-SU26"
+
+    def test_suggest_with_section(self):
+        name = OrgNameValidator.suggest("SOC", "CS3550", "Smith", "SP", "26", section="2")
+        assert name == "SOC-CS3550-2-Smith-SP26"
+
+    def test_suggest_normalizes_lowercase_input(self):
+        name = OrgNameValidator.suggest("soc", "cs3030", "valle", "su", "26")
+        assert name == "SOC-CS3030-Valle-SU26"
+
+    def test_suggest_invalid_semester_defaults_to_fa(self):
+        name = OrgNameValidator.suggest("SOC", "CS3030", "Valle", "WINTER", "26")
+        assert "FA" in name
+
+    def test_suggest_strips_special_chars(self):
+        name = OrgNameValidator.suggest("S O C!", "CS 3030", "Val-le", "SU", "26")
+        assert "SOC" in name
+        assert "CS3030" in name

--- a/tests/test_organization_workspace.py
+++ b/tests/test_organization_workspace.py
@@ -1,0 +1,261 @@
+"""
+Tests for classdock.organizations.workspace.WorkspaceManager.
+
+Uses temporary directories; no network or real git operations.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from classdock.organizations.models import TemplateRepo
+from classdock.organizations.workspace import WorkspaceManager
+
+
+@pytest.fixture()
+def tmp_workspace(tmp_path):
+    """Return a tmp_path with a basic workspace layout."""
+    return tmp_path
+
+
+@pytest.fixture()
+def manager(tmp_workspace):
+    return WorkspaceManager(base_path=tmp_workspace)
+
+
+# ---------------------------------------------------------------------------
+# Master folder discovery
+# ---------------------------------------------------------------------------
+
+class TestFindMasterFolder:
+    def test_finds_marker_in_base(self, tmp_workspace, manager):
+        (tmp_workspace / ".classdock-master").touch()
+        wf = manager.find_master_folder(start=tmp_workspace)
+        assert wf is not None
+        assert wf.is_master
+        assert wf.path == tmp_workspace
+
+    def test_finds_marker_in_parent(self, tmp_workspace, manager):
+        (tmp_workspace / ".classdock-master").touch()
+        child = tmp_workspace / "subdir"
+        child.mkdir()
+        wf = manager.find_master_folder(start=child)
+        assert wf is not None
+        assert wf.path == tmp_workspace
+
+    def test_returns_none_when_no_marker(self, tmp_workspace, manager):
+        assert manager.find_master_folder(start=tmp_workspace) is None
+
+    def test_course_code_set_from_folder_name(self, tmp_workspace, manager):
+        master = tmp_workspace / "CS3030"
+        master.mkdir()
+        (master / ".classdock-master").touch()
+        wf = manager.find_master_folder(start=master)
+        assert wf.course_code == "CS3030"
+
+    def test_discovers_git_repos_inside(self, tmp_workspace, manager):
+        (tmp_workspace / ".classdock-master").touch()
+        repo_dir = tmp_workspace / "python-basics"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        wf = manager.find_master_folder(start=tmp_workspace)
+        assert len(wf.repos) == 1
+        assert wf.repos[0].name == "python-basics"
+
+    def test_ignores_non_git_subdirs(self, tmp_workspace, manager):
+        (tmp_workspace / ".classdock-master").touch()
+        (tmp_workspace / "not-a-repo").mkdir()
+        wf = manager.find_master_folder(start=tmp_workspace)
+        assert wf.repos == []
+
+
+# ---------------------------------------------------------------------------
+# Init master folder
+# ---------------------------------------------------------------------------
+
+class TestInitMasterFolder:
+    def test_creates_directory(self, tmp_workspace, manager):
+        target = tmp_workspace / "CS3030"
+        manager.init_master_folder(target, "CS3030")
+        assert target.is_dir()
+
+    def test_creates_marker_file(self, tmp_workspace, manager):
+        target = tmp_workspace / "CS3030"
+        manager.init_master_folder(target, "CS3030")
+        assert (target / ".classdock-master").exists()
+
+    def test_marker_contains_course_code(self, tmp_workspace, manager):
+        target = tmp_workspace / "CS3030"
+        manager.init_master_folder(target, "CS3030")
+        assert (target / ".classdock-master").read_text() == "CS3030"
+
+    def test_returns_workspace_folder(self, tmp_workspace, manager):
+        target = tmp_workspace / "CS3030"
+        wf = manager.init_master_folder(target, "CS3030")
+        assert wf.is_master
+        assert wf.course_code == "CS3030"
+
+    def test_idempotent_on_existing_dir(self, tmp_workspace, manager):
+        target = tmp_workspace / "CS3030"
+        target.mkdir()
+        wf = manager.init_master_folder(target, "CS3030")
+        assert wf.is_master
+
+
+# ---------------------------------------------------------------------------
+# Org folder creation
+# ---------------------------------------------------------------------------
+
+class TestCreateOrgFolder:
+    def test_creates_directory(self, tmp_workspace, manager):
+        wf = manager.create_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        assert (tmp_workspace / "SOC-CS3030-Valle-SU26").is_dir()
+
+    def test_creates_marker_file(self, tmp_workspace, manager):
+        wf = manager.create_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        marker = wf.path / ".classdock-org"
+        assert marker.exists()
+
+    def test_returns_workspace_folder(self, tmp_workspace, manager):
+        wf = manager.create_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        assert not wf.is_master
+        assert wf.org_name == "SOC-CS3030-Valle-SU26"
+
+
+class TestFindOrgFolder:
+    def test_returns_none_when_not_exists(self, tmp_workspace, manager):
+        assert manager.find_org_folder(tmp_workspace, "nonexistent-org") is None
+
+    def test_returns_folder_when_exists(self, tmp_workspace, manager):
+        (tmp_workspace / "SOC-CS3030-Valle-SU26").mkdir()
+        wf = manager.find_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        assert wf is not None
+        assert wf.org_name == "SOC-CS3030-Valle-SU26"
+
+
+# ---------------------------------------------------------------------------
+# Local git-clone operations
+# ---------------------------------------------------------------------------
+
+class TestCloneRepoLocally:
+    def test_success_returns_path(self, tmp_workspace, manager):
+        target = tmp_workspace / "my-repo"
+
+        def fake_run(cmd, **kwargs):
+            target.mkdir()
+            result = subprocess.CompletedProcess(cmd, returncode=0)
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with patch("classdock.organizations.workspace.subprocess.run", side_effect=fake_run):
+            path = manager.clone_repo_locally(
+                "https://github.com/org/my-repo.git", tmp_workspace, "my-repo"
+            )
+        assert path == target
+
+    def test_failure_returns_none(self, tmp_workspace, manager):
+        def fake_run(cmd, **kwargs):
+            result = subprocess.CompletedProcess(cmd, returncode=128)
+            result.stdout = ""
+            result.stderr = "fatal: repository not found"
+            return result
+
+        with patch("classdock.organizations.workspace.subprocess.run", side_effect=fake_run):
+            path = manager.clone_repo_locally(
+                "https://github.com/org/bad-repo.git", tmp_workspace, "bad-repo"
+            )
+        assert path is None
+
+    def test_skips_if_already_exists(self, tmp_workspace, manager):
+        existing = tmp_workspace / "existing-repo"
+        existing.mkdir()
+
+        with patch("classdock.organizations.workspace.subprocess.run") as mock_run:
+            path = manager.clone_repo_locally(
+                "https://github.com/org/existing-repo.git", tmp_workspace, "existing-repo"
+            )
+            mock_run.assert_not_called()
+
+        assert path == existing
+
+
+class TestCloneTemplatesLocally:
+    def test_clones_all_repos(self, tmp_workspace, manager):
+        repos = [
+            TemplateRepo(
+                name="repo-a", owner="org",
+                clone_url="https://github.com/org/repo-a.git"
+            ),
+            TemplateRepo(
+                name="repo-b", owner="org",
+                clone_url="https://github.com/org/repo-b.git"
+            ),
+        ]
+
+        def fake_clone(url, dest, name):
+            p = dest / name
+            p.mkdir()
+            return p
+
+        with patch.object(manager, "clone_repo_locally", side_effect=fake_clone):
+            cloned = manager.clone_templates_locally(repos, tmp_workspace)
+
+        assert len(cloned) == 2
+        assert cloned[0].local_path is not None
+
+    def test_skips_repos_without_clone_url(self, tmp_workspace, manager):
+        repos = [TemplateRepo(name="no-url-repo", owner="org", clone_url="")]
+        with patch.object(manager, "clone_repo_locally") as mock_clone:
+            result = manager.clone_templates_locally(repos, tmp_workspace)
+            mock_clone.assert_not_called()
+        assert result == []
+
+    def test_progress_callback_called(self, tmp_workspace, manager):
+        repos = [
+            TemplateRepo(name="r", owner="o", clone_url="https://github.com/o/r.git")
+        ]
+        calls = []
+
+        def fake_clone(url, dest, name):
+            p = dest / name
+            p.mkdir()
+            return p
+
+        with patch.object(manager, "clone_repo_locally", side_effect=fake_clone):
+            manager.clone_templates_locally(
+                repos, tmp_workspace,
+                progress_callback=lambda cur, tot, nm: calls.append((cur, tot, nm))
+            )
+
+        assert calls == [(1, 1, "r")]
+
+
+# ---------------------------------------------------------------------------
+# Discovery helper
+# ---------------------------------------------------------------------------
+
+class TestDiscoverReposInFolder:
+    def test_finds_git_dirs(self, tmp_workspace, manager):
+        for name in ["repo-a", "repo-b"]:
+            d = tmp_workspace / name
+            d.mkdir()
+            (d / ".git").mkdir()
+
+        repos = manager.list_repos_in_folder(tmp_workspace)
+        assert len(repos) == 2
+        assert {r.name for r in repos} == {"repo-a", "repo-b"}
+
+    def test_ignores_non_git_dirs(self, tmp_workspace, manager):
+        (tmp_workspace / "not-a-repo").mkdir()
+        assert manager.list_repos_in_folder(tmp_workspace) == []
+
+    def test_returns_sorted_by_name(self, tmp_workspace, manager):
+        for name in ["zzz", "aaa", "mmm"]:
+            d = tmp_workspace / name
+            d.mkdir()
+            (d / ".git").mkdir()
+        repos = manager.list_repos_in_folder(tmp_workspace)
+        assert [r.name for r in repos] == ["aaa", "mmm", "zzz"]

--- a/tests/test_organizations_cli.py
+++ b/tests/test_organizations_cli.py
@@ -14,6 +14,7 @@ from classdock.organizations.models import (
     CloneResult,
     Organization,
     SetupResult,
+    TemplateRepo,
 )
 
 runner = CliRunner(mix_stderr=False)
@@ -48,6 +49,18 @@ class TestOrgList:
         assert "SOC-CS3030-Valle-SU26" in result.output
 
 
+def _mock_template_manager(repos=None):
+    m = MagicMock()
+    m.return_value.list_org_repos.return_value = repos or []
+    return m
+
+
+_SAMPLE_REPOS = [
+    TemplateRepo(name="python-basics", owner="SOC-CS3030-Valle-SU26", is_template=True),
+    TemplateRepo(name="midterm-project", owner="SOC-CS3030-Valle-SU26", is_template=False),
+]
+
+
 class TestOrgVerify:
     def test_valid_org_found(self):
         org = Organization(
@@ -56,30 +69,60 @@ class TestOrgVerify:
             url="https://github.com/SOC-CS3030-Valle-SU26",
             role="admin",
         )
-        with patch(
-            "classdock.commands.organizations.OrganizationManager",
-            _mock_org_manager(org=org),
+        with (
+            patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
+            patch("classdock.commands.organizations.TemplateManager", _mock_template_manager(_SAMPLE_REPOS)),
         ):
             result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
         assert result.exit_code == 0
         assert "verified" in result.output.lower()
 
+    def test_shows_repo_count(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        with (
+            patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
+            patch("classdock.commands.organizations.TemplateManager", _mock_template_manager(_SAMPLE_REPOS)),
+        ):
+            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+        assert result.exit_code == 0
+        assert "2" in result.output   # total repos
+        assert "1" in result.output   # template repos
+
+    def test_shows_repo_names(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        with (
+            patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
+            patch("classdock.commands.organizations.TemplateManager", _mock_template_manager(_SAMPLE_REPOS)),
+        ):
+            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+        assert "python-basics" in result.output
+        assert "midterm-project" in result.output
+
     def test_org_not_found_exits_1(self):
-        with patch(
-            "classdock.commands.organizations.OrganizationManager",
-            _mock_org_manager(org=None),
+        with (
+            patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=None)),
         ):
             result = runner.invoke(app, ["organizations", "verify", "ghost-org"])
         assert result.exit_code == 1
 
     def test_invalid_name_shows_warning(self):
         org = Organization(login="my-plain-org")
-        with patch(
-            "classdock.commands.organizations.OrganizationManager",
-            _mock_org_manager(org=org),
+        with (
+            patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
+            patch("classdock.commands.organizations.TemplateManager", _mock_template_manager([])),
         ):
             result = runner.invoke(app, ["organizations", "verify", "my-plain-org"])
         assert "Warning" in result.output or result.exit_code in (0, 1)
+
+    def test_no_repos_shows_empty(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26")
+        with (
+            patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
+            patch("classdock.commands.organizations.TemplateManager", _mock_template_manager([])),
+        ):
+            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+        assert result.exit_code == 0
+        assert "0" in result.output
 
 
 class TestOrgCreate:

--- a/tests/test_organizations_cli.py
+++ b/tests/test_organizations_cli.py
@@ -1,0 +1,196 @@
+"""
+Tests for classdock.commands.organizations CLI command group.
+
+Uses Typer's test runner; no real network or filesystem access.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from classdock.cli import app
+from classdock.organizations.models import (
+    CloneResult,
+    Organization,
+    SetupResult,
+)
+
+runner = CliRunner(mix_stderr=False)
+
+
+def _mock_org_manager(orgs=None, org=None, exists=True):
+    m = MagicMock()
+    m.return_value.list_user_organizations.return_value = orgs or []
+    m.return_value.get_organization.return_value = org
+    m.return_value.organization_exists.return_value = exists
+    return m
+
+
+class TestOrgList:
+    def test_empty_org_list(self):
+        with patch(
+            "classdock.commands.organizations.OrganizationManager",
+            _mock_org_manager(orgs=[]),
+        ):
+            result = runner.invoke(app, ["organizations", "list"])
+        assert result.exit_code == 0
+        assert "No organizations found" in result.output
+
+    def test_shows_org_table(self):
+        org = Organization(login="SOC-CS3030-Valle-SU26", name="CS3030", role="admin")
+        with patch(
+            "classdock.commands.organizations.OrganizationManager",
+            _mock_org_manager(orgs=[org]),
+        ):
+            result = runner.invoke(app, ["organizations", "list"])
+        assert result.exit_code == 0
+        assert "SOC-CS3030-Valle-SU26" in result.output
+
+
+class TestOrgVerify:
+    def test_valid_org_found(self):
+        org = Organization(
+            login="SOC-CS3030-Valle-SU26",
+            name="CS3030 SU26",
+            url="https://github.com/SOC-CS3030-Valle-SU26",
+            role="admin",
+        )
+        with patch(
+            "classdock.commands.organizations.OrganizationManager",
+            _mock_org_manager(org=org),
+        ):
+            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+        assert result.exit_code == 0
+        assert "verified" in result.output.lower()
+
+    def test_org_not_found_exits_1(self):
+        with patch(
+            "classdock.commands.organizations.OrganizationManager",
+            _mock_org_manager(org=None),
+        ):
+            result = runner.invoke(app, ["organizations", "verify", "ghost-org"])
+        assert result.exit_code == 1
+
+    def test_invalid_name_shows_warning(self):
+        org = Organization(login="my-plain-org")
+        with patch(
+            "classdock.commands.organizations.OrganizationManager",
+            _mock_org_manager(org=org),
+        ):
+            result = runner.invoke(app, ["organizations", "verify", "my-plain-org"])
+        assert "Warning" in result.output or result.exit_code in (0, 1)
+
+
+class TestOrgCreate:
+    def test_invalid_name_exits_1(self):
+        result = runner.invoke(
+            app,
+            ["organizations", "create", "--login", "bad name!", "--email", "a@b.com"],
+        )
+        assert result.exit_code == 1
+
+    def test_dry_run_does_not_call_api(self):
+        with patch("classdock.commands.organizations.OrganizationManager") as mock_mgr:
+            result = runner.invoke(
+                app,
+                [
+                    "--dry-run",
+                    "organizations",
+                    "create",
+                    "--login",
+                    "SOC-CS3030-Valle-SU26",
+                    "--email",
+                    "a@b.com",
+                ],
+            )
+        mock_mgr.return_value.create_organization.assert_not_called()
+        assert result.exit_code == 0
+
+    def test_permission_error_exits_1(self):
+        mock_mgr_instance = MagicMock()
+        mock_mgr_instance.create_organization.side_effect = PermissionError("admin:org required")
+
+        with patch(
+            "classdock.commands.organizations.OrganizationManager",
+            return_value=mock_mgr_instance,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "organizations",
+                    "create",
+                    "--login",
+                    "SOC-CS3030-Valle-SU26",
+                    "--email",
+                    "a@b.com",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "Permission" in result.output
+
+
+class TestOrgCloneTemplates:
+    def test_successful_clone(self):
+        clone_result = CloneResult(total=2, successful=2)
+
+        with patch(
+            "classdock.commands.organizations.OrganizationService"
+        ) as mock_svc_cls:
+            mock_svc_cls.return_value.clone_templates.return_value = clone_result
+            result = runner.invoke(
+                app,
+                [
+                    "organizations",
+                    "clone-templates",
+                    "--source-org",
+                    "CS3030",
+                    "--target-org",
+                    "SOC-CS3030-Valle-SU26",
+                    "--repos",
+                    "python-basics",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "2/2" in result.output
+
+    def test_partial_failure_exits_1(self):
+        clone_result = CloneResult(total=2, successful=1, failed=1)
+        clone_result.errors.append("fork failed")
+
+        with patch(
+            "classdock.commands.organizations.OrganizationService"
+        ) as mock_svc_cls:
+            mock_svc_cls.return_value.clone_templates.return_value = clone_result
+            result = runner.invoke(
+                app,
+                [
+                    "organizations",
+                    "clone-templates",
+                    "--source-org",
+                    "CS3030",
+                    "--target-org",
+                    "SOC-CS3030-Valle-SU26",
+                ],
+            )
+        assert result.exit_code == 1
+
+    def test_zero_repos_shows_message(self):
+        clone_result = CloneResult(total=0)
+
+        with patch(
+            "classdock.commands.organizations.OrganizationService"
+        ) as mock_svc_cls:
+            mock_svc_cls.return_value.clone_templates.return_value = clone_result
+            result = runner.invoke(
+                app,
+                [
+                    "organizations",
+                    "clone-templates",
+                    "--source-org",
+                    "CS3030",
+                    "--target-org",
+                    "SOC-CS3030-Valle-SU26",
+                ],
+            )
+        assert "No repositories" in result.output

--- a/tests/test_organizations_cli.py
+++ b/tests/test_organizations_cli.py
@@ -175,7 +175,10 @@ class TestOrgCreate:
 
 class TestOrgCloneTemplates:
     def test_successful_clone(self):
-        clone_result = CloneResult(total=2, successful=2)
+        repo = TemplateRepo(name="python-basics", owner="CS3030")
+        clone_result = CloneResult(total=1, successful=1)
+        clone_result.cloned_repos.append(repo)
+        clone_result.attempted_names.append("python-basics")
 
         with patch(
             "classdock.commands.organizations.OrganizationService"
@@ -195,7 +198,8 @@ class TestOrgCloneTemplates:
                 ],
             )
         assert result.exit_code == 0
-        assert "2/2" in result.output
+        assert "cloned" in result.output
+        assert "python-basics" in result.output
 
     def test_partial_failure_exits_1(self):
         clone_result = CloneResult(total=2, successful=1, failed=1)
@@ -217,6 +221,32 @@ class TestOrgCloneTemplates:
                 ],
             )
         assert result.exit_code == 1
+
+    def test_already_existed_shown_in_table(self):
+        clone_result = CloneResult(total=2, successful=1)
+        clone_result.cloned_repos.append(TemplateRepo(name="new-repo", owner="CS3030"))
+        clone_result.already_existed.append("old-repo")
+        clone_result.attempted_names.extend(["new-repo", "old-repo"])
+
+        with patch(
+            "classdock.commands.organizations.OrganizationService"
+        ) as mock_svc_cls:
+            mock_svc_cls.return_value.clone_templates.return_value = clone_result
+            result = runner.invoke(
+                app,
+                [
+                    "organizations",
+                    "clone-templates",
+                    "--source-org",
+                    "CS3030",
+                    "--target-org",
+                    "SOC-CS3030-Valle-SU26",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "exists" in result.output
+        assert "cloned" in result.output
+        assert "already existed" in result.output
 
     def test_zero_repos_shows_message(self):
         clone_result = CloneResult(total=0)


### PR DESCRIPTION
## Summary

- Implements organization-level workspace management (Issue #35): master template folder + semester org folder structure
- Adds \`classdock organizations\` command group: \`init\`, \`create\`, \`list\`, \`clone-templates\`, \`verify\`
- Adds \`classdock organizations classroom\` subgroup: \`list\`, \`assignments\`, \`grades\`, \`clone\`
  - \`assignments\` and \`grades\` use a 3-level interactive drill-down: org → classroom → assignment → student data
- GitHub Classroom API integration (read-only): lists classrooms, assignments, student repos, grades
- Generates deep-link URLs for one-click assignment creation in the GitHub Classroom web UI
- Writes \`classroom_setup.md\` into the org workspace folder after cloning
- Updates \`docs/ORGANIZATION_SETUP.md\` with full command reference, examples, and semester workflow

## Bug fix (added during testing)

\`classroom clone\` crashed when \`--workspace\` directory did not exist — added \`mkdir(parents=True, exist_ok=True)\` before writing \`classroom_setup.md\` in both \`commands/organizations.py\` and \`organizations/wizard.py\`.

## Test plan

- [x] \`poetry run pytest tests/ -v\` — all 1135 tests pass
- [x] \`classdock organizations init\` — wizard flow (interactive terminal)
- [x] \`classdock organizations verify SOC-CS3030-Valle-FA26\` — org details + repo count
- [x] \`classdock organizations clone-templates --source-org cs3030-master --target-org SOC-CS3030-Valle-FA26\` — options and help verified
- [x] \`classdock organizations classroom list\` — all classrooms with org column
- [x] \`classdock organizations classroom assignments CS3030-Valle-S26\` — 3-level drill-down (org → classroom → 6 assignments → 31 student repos)
- [x] \`classdock organizations classroom grades CS3030-Valle-S26\` — 3-level drill-down (31 students with submission timestamps)
- [x] \`classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26\` — checklist table + \`classroom_setup.md\` written

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)