### PR TITLE
Release v0.4.1

### DIFF
--- a/.github/scripts/test_cli_commands.sh
+++ b/.github/scripts/test_cli_commands.sh
@@ -35,7 +35,7 @@ $CLASSDOCK_CMD automation --help
 print_message "step" "Testing specific command help..."
 $CLASSDOCK_CMD assignments orchestrate --help
 $CLASSDOCK_CMD repos fetch --help
-$CLASSDOCK_CMD secrets manage --help
+$CLASSDOCK_CMD secrets add --help
 
 # Test error conditions
 print_message "step" "Testing error conditions..."

--- a/.github/scripts/test_error_recovery.sh
+++ b/.github/scripts/test_error_recovery.sh
@@ -27,7 +27,7 @@ EOF
     
     # Test that the CLI properly handles invalid configuration
     set +e
-    poetry run classdock assignments --dry-run orchestrate \
+    poetry run classdock assignments orchestrate \
         --config "$TEST_CONFIG_DIR/invalid_assignment.conf" 2>/dev/null
     exit_code=$?
     set -e

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,7 +23,7 @@ jobs:
       is-hotfix: ${{ steps.check.outputs.is-hotfix }}
       branch-name: ${{ steps.check.outputs.branch-name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
     needs: check-hotfix
     if: needs.check-hotfix.outputs.is-hotfix == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-3.11-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📦 Load workflow utilities
         run: |
@@ -53,7 +53,7 @@ jobs:
     needs: security-monitoring
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -104,7 +104,7 @@ jobs:
     needs: [security-monitoring, update-dependencies]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📦 Load workflow utilities
         run: |
@@ -123,7 +123,7 @@ jobs:
         run: ./.github/scripts/generate_comprehensive_health_summary.sh "$HEALTH_CHECK_START" "${{ needs.security-monitoring.outputs.advisories }}" "${{ needs.security-monitoring.outputs.vulnerabledeps }}" "${{ needs.security-monitoring.outputs.updatesneeded }}"
 
       - name: 📤 Upload workflow status artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: auto-update-workflow-status

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -17,7 +17,7 @@ jobs:
     if: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Protect main branch
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ["3.10", "3.12", "3.14"]
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -39,7 +39,7 @@ jobs:
           cache: "pip" # Cache pip dependencies
 
       - name: 📦 Cache Poetry installation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.local/share/pypoetry
@@ -60,7 +60,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: � Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-test-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
@@ -117,7 +117,7 @@ jobs:
           print_message "success" "All tests passed for Python ${{ matrix.python-version }}"
 
       - name: 📊 Upload test results and coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: test-results-python${{ matrix.python-version }}
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
@@ -159,7 +159,7 @@ jobs:
           cache: "pip"
 
       - name: 📦 Cache Poetry installation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.local/share/pypoetry
@@ -180,7 +180,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: 📦 Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-lint-${{ runner.os }}-3.11-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code (for utilities)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📦 Load workflow utilities
         run: |
@@ -245,7 +245,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -256,7 +256,7 @@ jobs:
           cache: "pip"
 
       - name: 📦 Cache security tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /tmp/security-scan-cache

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.11'
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
       
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
           ./.github/scripts/create_integration_test_config.sh basic tests/fixtures
 
       - name: Upload Integration Test Configuration
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: integration-test-config
           path: tests/fixtures/
@@ -67,7 +67,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python Environment
         uses: actions/setup-python@v5
@@ -82,7 +82,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-integration-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }}
@@ -91,7 +91,7 @@ jobs:
         run: poetry install
 
       - name: Download Integration Test Configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: integration-test-config
           path: tests/fixtures/
@@ -121,7 +121,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python Environment
         uses: actions/setup-python@v5
@@ -136,7 +136,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-integration-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }}
@@ -145,7 +145,7 @@ jobs:
         run: poetry install
 
       - name: Download Integration Test Configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: integration-test-config
           path: tests/fixtures/
@@ -182,7 +182,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python Environment
         uses: actions/setup-python@v5
@@ -197,7 +197,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-integration-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }}
@@ -206,7 +206,7 @@ jobs:
         run: poetry install
 
       - name: Download Integration Test Configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: integration-test-config
           path: tests/fixtures/
@@ -233,7 +233,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python Environment
         uses: actions/setup-python@v5
@@ -248,7 +248,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-integration-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }}
@@ -257,7 +257,7 @@ jobs:
         run: poetry install
 
       - name: Download Integration Test Configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: integration-test-config
           path: tests/fixtures/
@@ -293,7 +293,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python Environment
         uses: actions/setup-python@v5
@@ -308,7 +308,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-integration-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }}
@@ -317,7 +317,7 @@ jobs:
         run: poetry install
 
       - name: Download Integration Test Configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: integration-test-config
           path: tests/fixtures/
@@ -354,10 +354,10 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download All Integration Test Results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: 'integration-*'
           path: all_integration_results/
@@ -377,7 +377,7 @@ jobs:
           export_performance_metrics "integration_testing" "all_integration_results/final_metrics.json"
 
       - name: Upload Integration Test Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: integration-test-final-report

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-perf-${{ runner.os }}-3.11-${{ hashFiles('**/poetry.lock') }}
@@ -190,7 +190,7 @@ jobs:
           export_performance_metrics "script_performance" "performance_results/metrics.json"
 
       - name: Upload Performance Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: script-performance-${{ matrix.scenario.name }}
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python Environment
         uses: actions/setup-python@v5
@@ -272,9 +272,9 @@ jobs:
           start_step_timing "cli_secrets_benchmark"
 
           # Benchmark secrets management CLI command
-          benchmark_script "cli_secrets_manage" \
-            "poetry run classdock secrets --dry-run manage" \
-            "--config assignment.conf"
+          benchmark_script "cli_secrets_add" \
+            "poetry run classdock secrets --dry-run add" \
+            "--assignment-root assignment.conf"
 
           end_step_timing "cli_secrets_benchmark"
 
@@ -290,7 +290,7 @@ jobs:
           export_performance_metrics "cli_performance" "cli_results/metrics.json"
 
       - name: Upload CLI Performance Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: cli-performance-results
@@ -306,10 +306,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download All Performance Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: "*-performance-*"
           path: all_performance_results/
@@ -347,7 +347,7 @@ jobs:
           export_performance_metrics "performance_monitoring" "aggregated_results/final_metrics.json"
 
       - name: Upload Final Performance Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: performance-monitoring-final

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       release-type: ${{ steps.check.outputs.release-type }}
     steps:
     - name: 📥 Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         
@@ -74,7 +74,7 @@ jobs:
     
     steps:
     - name: 📥 Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: 🐍 Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -90,7 +90,7 @@ jobs:
         
     - name: 🔧 Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -113,7 +113,7 @@ jobs:
         
     - name: 📤 Upload coverage to Codecov
       if: matrix.python-version == '3.12'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests
@@ -141,7 +141,7 @@ jobs:
       
     steps:
     - name: 📥 Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0  # Full history for changelog
         
@@ -449,7 +449,7 @@ jobs:
     
     steps:
     - name: 📥 Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         ref: main

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Full history for comprehensive analysis
 
@@ -66,7 +66,7 @@ jobs:
           print_message "success" "Security audit directories created"
 
       - name: 💾 Cache security audit data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /tmp/security-audit
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-security-audit-
 
       - name: 🏗️ Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -483,7 +483,7 @@ jobs:
           print_message "success" "Security metrics collected - Score: $security_score/100, Critical: $critical_vulns, High: $high_vulns, Secrets: $secret_findings"
 
       - name: 📤 Archive comprehensive security artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: comprehensive-security-audit-${{ github.sha }}
@@ -637,7 +637,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📝 Create security advisory issue
         uses: actions/github-script@v7

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync labels
         uses: EndBug/label-sync@v2

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -97,7 +97,7 @@ def org_init(ctx: typer.Context):
 def org_create(
     ctx: typer.Context,
     login: str = typer.Option(
-        ..., "--login", help="Organization login (e.g., SOC-CS3030-Valle-SU26)"
+        ..., "--login", help="Organization login (e.g., soc-cs3030-valle-su26)"
     ),
     email: str = typer.Option(..., "--email", help="Billing contact email"),
     name: Optional[str] = typer.Option(
@@ -110,8 +110,8 @@ def org_create(
     Requires the ``admin:org`` scope on your GitHub token.
 
     Examples:
-        $ classdock organizations create --login SOC-CS3030-Valle-SU26 --email me@weber.edu
-        $ classdock organizations create --login SOC-CS3030-Valle-SU26 --email me@weber.edu --name "CS3030 SU26"
+        $ classdock organizations create --login soc-cs3030-valle-su26 --email me@weber.edu
+        $ classdock organizations create --login soc-cs3030-valle-su26 --email me@weber.edu --name "CS3030 SU26"
     """
     verbose, dry_run = get_global_options(ctx)
     setup_logging(verbose)
@@ -206,11 +206,11 @@ def org_clone_templates(
     Examples:
         $ classdock organizations clone-templates \\
               --source-org CS3030 \\
-              --target-org SOC-CS3030-Valle-SU26
+              --target-org soc-cs3030-valle-su26
 
         $ classdock organizations clone-templates \\
               --source-org CS3030 \\
-              --target-org SOC-CS3030-Valle-SU26 \\
+              --target-org soc-cs3030-valle-su26 \\
               --repos python-basics \\
               --repos midterm-project
     """
@@ -279,7 +279,7 @@ def org_verify(
     Verify that a GitHub organization exists and show its details.
 
     Examples:
-        $ classdock organizations verify SOC-CS3030-Valle-SU26
+        $ classdock organizations verify soc-cs3030-valle-su26
     """
     verbose, _ = get_global_options(ctx)
     setup_logging(verbose)
@@ -318,7 +318,7 @@ def org_verify(
         if val.is_valid:
             table.add_row("Semester", val.semester_label or "—")
             table.add_row("Year", val.full_year or "—")
-            table.add_row("Instructor", val.lastname or "—")
+            table.add_row("Instructor", val.last_name or "—")
 
         console.print(table)
 
@@ -355,7 +355,7 @@ organizations_app.add_typer(classroom_app, name="classroom")
 def classroom_list(
     ctx: typer.Context,
     org_login: Optional[str] = typer.Argument(
-        None, help="Filter classrooms by GitHub org login (e.g., SOC-CS3030-Valle-FA26)"
+        None, help="Filter classrooms by GitHub org login (e.g., soc-cs3030-valle-fa26)"
     ),
 ):
     """
@@ -363,7 +363,7 @@ def classroom_list(
 
     Examples:
         $ classdock organizations classroom list
-        $ classdock organizations classroom list SOC-CS3030-Valle-FA26
+        $ classdock organizations classroom list soc-cs3030-valle-fa26
     """
     setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
     try:
@@ -417,7 +417,7 @@ def classroom_assignments(
     ctx: typer.Context,
     org_login: Optional[str] = typer.Argument(
         None,
-        help="GitHub organization login to filter classrooms (e.g., SOC-CS3030-Valle-FA26). "
+        help="GitHub organization login to filter classrooms (e.g., soc-cs3030-valle-fa26). "
         "If omitted, you will be prompted to select from all accessible classrooms.",
     ),
 ):
@@ -429,7 +429,7 @@ def classroom_assignments(
 
     Examples:
         $ classdock organizations classroom assignments
-        $ classdock organizations classroom assignments SOC-CS3030-Valle-FA26
+        $ classdock organizations classroom assignments soc-cs3030-valle-fa26
     """
     setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
     try:
@@ -576,7 +576,7 @@ def classroom_grades(
 
     Examples:
         $ classdock organizations classroom grades
-        $ classdock organizations classroom grades SOC-CS3030-Valle-FA26
+        $ classdock organizations classroom grades soc-cs3030-valle-fa26
     """
     setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)
     try:
@@ -709,8 +709,8 @@ def classroom_clone(
     must be completed manually — this command gives you everything you need.
 
     Examples:
-        $ classdock organizations classroom clone 12345 SOC-CS3030-Valle-FA26
-        $ classdock organizations classroom clone 12345 SOC-CS3030-Valle-FA26 --workspace ~/courses/SOC-CS3030-Valle-FA26
+        $ classdock organizations classroom clone 12345 soc-cs3030-valle-fa26
+        $ classdock organizations classroom clone 12345 soc-cs3030-valle-fa26 --workspace ~/courses/soc-cs3030-valle-fa26
     """
     import re as _re
     from pathlib import Path as _Path

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -6,14 +6,14 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ._helpers import get_global_options
-from ..utils import get_logger, setup_logging
 from ..organizations.classroom import ClassroomManager
 from ..organizations.manager import OrganizationManager
 from ..organizations.templates import TemplateManager
 from ..organizations.validators import OrgNameValidator
 from ..services.organization_service import OrganizationService
+from ..utils import get_logger, setup_logging
 from ..utils.github_classroom_api import GitHubClassroomAPIError
+from ._helpers import get_global_options
 
 logger = get_logger("cli.organizations")
 console = Console()
@@ -714,6 +714,7 @@ def classroom_clone(
     """
     import re as _re
     from pathlib import Path as _Path
+
     from rich.panel import Panel
 
     setup_logging(ctx.obj.get("verbose", False) if ctx.obj else False)

--- a/classdock/commands/organizations.py
+++ b/classdock/commands/organizations.py
@@ -23,9 +23,11 @@ def _get_token() -> Optional[str]:
     """Load the GitHub token from classdock's token store (same priority as other commands)."""
     try:
         from ..utils.token_manager import GitHubTokenManager
+
         return GitHubTokenManager().get_github_token()
     except Exception:
         return None
+
 
 organizations_app = typer.Typer(
     help="GitHub organization lifecycle management: create, list, and clone templates."
@@ -73,7 +75,9 @@ def org_init(ctx: typer.Context):
     setup_logging(verbose)
 
     try:
-        service = OrganizationService(token=_get_token(), dry_run=dry_run, verbose=verbose)
+        service = OrganizationService(
+            token=_get_token(), dry_run=dry_run, verbose=verbose
+        )
         ok, message = service.setup()
 
         if ok:
@@ -92,9 +96,13 @@ def org_init(ctx: typer.Context):
 @organizations_app.command("create")
 def org_create(
     ctx: typer.Context,
-    login: str = typer.Option(..., "--login", help="Organization login (e.g., SOC-CS3030-Valle-SU26)"),
+    login: str = typer.Option(
+        ..., "--login", help="Organization login (e.g., SOC-CS3030-Valle-SU26)"
+    ),
     email: str = typer.Option(..., "--email", help="Billing contact email"),
-    name: Optional[str] = typer.Option(None, "--name", help="Organization display name"),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Organization display name"
+    ),
 ):
     """
     Create a new GitHub organization (non-interactive).
@@ -119,7 +127,9 @@ def org_create(
 
     try:
         mgr = OrganizationManager(token=_get_token())
-        org = mgr.create_organization(login=login, billing_email=email, display_name=name)
+        org = mgr.create_organization(
+            login=login, billing_email=email, display_name=name
+        )
         console.print(f"[green]✓ Organization '{org.login}' created.[/green]")
         if org.url:
             console.print(f"  URL: {org.url}")
@@ -175,8 +185,12 @@ def org_list(ctx: typer.Context):
 @organizations_app.command("clone-templates")
 def org_clone_templates(
     ctx: typer.Context,
-    source_org: str = typer.Option(..., "--source-org", help="Organization to clone templates from"),
-    target_org: str = typer.Option(..., "--target-org", help="Organization to clone templates into"),
+    source_org: str = typer.Option(
+        ..., "--source-org", help="Organization to clone templates from"
+    ),
+    target_org: str = typer.Option(
+        ..., "--target-org", help="Organization to clone templates into"
+    ),
     repos: Optional[List[str]] = typer.Option(
         None,
         "--repos",
@@ -204,7 +218,9 @@ def org_clone_templates(
     setup_logging(verbose)
 
     try:
-        service = OrganizationService(token=_get_token(), dry_run=dry_run, verbose=verbose)
+        service = OrganizationService(
+            token=_get_token(), dry_run=dry_run, verbose=verbose
+        )
         result = service.clone_templates(
             source_org=source_org,
             target_org=target_org,
@@ -237,7 +253,9 @@ def org_clone_templates(
         if result.successful:
             parts.append(f"[green]{result.successful} cloned[/green]")
         if result.already_existed:
-            parts.append(f"[yellow]{len(result.already_existed)} already existed[/yellow]")
+            parts.append(
+                f"[yellow]{len(result.already_existed)} already existed[/yellow]"
+            )
         if result.failed:
             parts.append(f"[red]{result.failed} failed[/red]")
         console.print("\nSummary: " + " · ".join(parts))
@@ -309,7 +327,9 @@ def org_verify(
             repo_table.add_column("Name", style="cyan")
             repo_table.add_column("Template", justify="center")
             for repo in all_repos:
-                repo_table.add_row(repo.name, "[green]✓[/green]" if repo.is_template else "")
+                repo_table.add_row(
+                    repo.name, "[green]✓[/green]" if repo.is_template else ""
+                )
             console.print(repo_table)
 
         console.print("[green]✓ Organization verified.[/green]")
@@ -355,11 +375,17 @@ def classroom_list(
         )
 
         if not classrooms:
-            msg = f"No classrooms found" + (f" for '{org_login}'" if org_login else "") + "."
+            msg = (
+                f"No classrooms found"
+                + (f" for '{org_login}'" if org_login else "")
+                + "."
+            )
             console.print(f"[yellow]{msg}[/yellow]")
             return
 
-        title = f"Classrooms for '{org_login}'" if org_login else "Your GitHub Classrooms"
+        title = (
+            f"Classrooms for '{org_login}'" if org_login else "Your GitHub Classrooms"
+        )
         table = Table(title=title, show_header=True)
         table.add_column("ID", style="dim", justify="right")
         table.add_column("Name", style="cyan")
@@ -392,7 +418,7 @@ def classroom_assignments(
     org_login: Optional[str] = typer.Argument(
         None,
         help="GitHub organization login to filter classrooms (e.g., SOC-CS3030-Valle-FA26). "
-             "If omitted, you will be prompted to select from all accessible classrooms.",
+        "If omitted, you will be prompted to select from all accessible classrooms.",
     ),
 ):
     """
@@ -446,7 +472,9 @@ def classroom_assignments(
         # Step 3 — fetch and display assignments
         assignments = mgr.list_assignments(classroom.id)
         if not assignments:
-            console.print(f"[yellow]No assignments in classroom '{classroom.name}'.[/yellow]")
+            console.print(
+                f"[yellow]No assignments in classroom '{classroom.name}'.[/yellow]"
+            )
             return
 
         console.print(f"\n[bold]Assignments in {classroom.name}:[/bold]\n")
@@ -505,7 +533,9 @@ def classroom_assignments(
             submitted = "[green]✓[/green]" if entry.get("submitted") else ""
             passing = "[green]✓[/green]" if entry.get("passing") else ""
             commits = str(entry.get("commit_count", "—"))
-            grade = str(entry.get("grade", "—")) if entry.get("grade") is not None else "—"
+            grade = (
+                str(entry.get("grade", "—")) if entry.get("grade") is not None else "—"
+            )
 
             repo_table.add_row(
                 str(i), username, repo_name, submitted, passing, commits, grade
@@ -533,7 +563,7 @@ def classroom_grades(
     org_login: Optional[str] = typer.Argument(
         None,
         help="GitHub organization login to filter classrooms. "
-             "If omitted, all accessible classrooms are shown.",
+        "If omitted, all accessible classrooms are shown.",
     ),
 ):
     """
@@ -585,7 +615,9 @@ def classroom_grades(
         # Step 2 — assignment list
         assignments = mgr.list_assignments(classroom.id)
         if not assignments:
-            console.print(f"[yellow]No assignments in classroom '{classroom.name}'.[/yellow]")
+            console.print(
+                f"[yellow]No assignments in classroom '{classroom.name}'.[/yellow]"
+            )
             return
 
         console.print(f"\n[bold]Assignments in {classroom.name}:[/bold]\n")
@@ -598,9 +630,7 @@ def classroom_grades(
             )
 
         console.print()
-        choice = typer.prompt(
-            f"Select assignment [1-{len(assignments)}]", default="1"
-        )
+        choice = typer.prompt(f"Select assignment [1-{len(assignments)}]", default="1")
         try:
             aidx = int(choice) - 1
             if not 0 <= aidx < len(assignments):
@@ -744,7 +774,9 @@ def classroom_clone(
                         target_org=target_org,
                     )
                     new_repo = f"{target_org}/{repo_name}"
-                    cloned_status = "[green]✓ cloned[/green]" if result else "[red]✗ failed[/red]"
+                    cloned_status = (
+                        "[green]✓ cloned[/green]" if result else "[red]✗ failed[/red]"
+                    )
                 except Exception:
                     new_repo = f"{target_org}/{repo_name}"
                     cloned_status = "[yellow]↩ exists[/yellow]"
@@ -754,9 +786,7 @@ def classroom_clone(
                 cloned_status = "[dim][dry-run][/dim]"
 
             create_url = (
-                ClassroomManager.assignment_creation_url(
-                    target_classroom_id, new_repo
-                )
+                ClassroomManager.assignment_creation_url(target_classroom_id, new_repo)
                 if target_classroom_id
                 else ClassroomManager.new_classroom_url()
             )
@@ -792,9 +822,7 @@ def classroom_clone(
             for title, atype, deadline, _, url in rows:
                 lines.append(f"| {title} | {atype} | {deadline} | {url} |\n")
             md_path.write_text("".join(lines), encoding="utf-8")
-            console.print(
-                f"\n[dim]Checklist written to:[/dim] {md_path}"
-            )
+            console.print(f"\n[dim]Checklist written to:[/dim] {md_path}")
 
         console.print(
             Panel(

--- a/classdock/organizations/classroom.py
+++ b/classdock/organizations/classroom.py
@@ -17,7 +17,9 @@ from .models import Classroom, ClassroomAssignment
 
 logger = logging.getLogger(__name__)
 
-_CLASSROOM_NEW_URL = "https://classroom.github.com/classrooms/{classroom_id}/assignments/new"
+_CLASSROOM_NEW_URL = (
+    "https://classroom.github.com/classrooms/{classroom_id}/assignments/new"
+)
 
 
 class ClassroomManager:

--- a/classdock/organizations/manager.py
+++ b/classdock/organizations/manager.py
@@ -96,7 +96,7 @@ class OrganizationManager:
         making the API call.
 
         Args:
-            login: The organization slug (e.g., SOC-CS3030-Valle-SU26).
+            login: The organization slug (e.g., soc-cs3030-valle-su26).
             billing_email: Billing contact email for the new organization.
             display_name: Human-readable name for the organization.
                           Falls back to login if not provided.

--- a/classdock/organizations/models.py
+++ b/classdock/organizations/models.py
@@ -94,7 +94,9 @@ class TemplateRepo:
     def from_dict(cls, data: dict) -> "TemplateRepo":
         """Create TemplateRepo from a GitHub API response dict."""
         owner_login = (
-            data["owner"]["login"] if isinstance(data.get("owner"), dict) else data.get("owner", "")
+            data["owner"]["login"]
+            if isinstance(data.get("owner"), dict)
+            else data.get("owner", "")
         )
         return cls(
             name=data.get("name", ""),

--- a/classdock/organizations/templates.py
+++ b/classdock/organizations/templates.py
@@ -51,9 +51,7 @@ class TemplateManager:
         raw = self._api.list_org_repos(org_login, templates_only=True)
         repos = [TemplateRepo.from_dict(r) for r in raw]
         repos.sort(key=lambda r: r.name.lower())
-        logger.debug(
-            "Found %d template repos in '%s'", len(repos), org_login
-        )
+        logger.debug("Found %d template repos in '%s'", len(repos), org_login)
         return repos
 
     def list_org_repos(
@@ -123,7 +121,8 @@ class TemplateManager:
         # Fallback: try fork (for repos not marked as templates)
         logger.debug(
             "generate-from-template returned None for '%s/%s'; falling back to fork.",
-            source_owner, repo_name,
+            source_owner,
+            repo_name,
         )
         raw = self._api.fork_repository(
             owner=source_owner,

--- a/classdock/organizations/validators.py
+++ b/classdock/organizations/validators.py
@@ -2,29 +2,30 @@
 Naming convention validation for GitHub organizations.
 
 Enforces the ClassDock organization naming standard:
-  [SUBJECT]-[COURSE][SECTION?]-[LASTNAME]-[SEMESTER][YEAR]
+  [program?-][course][section?]-[last_name]-[semester][year]
 
 Examples:
-  SOC-CS3030-Valle-SU26        (single section)
-  SOC-CS3550-2-Smith-SP26      (section 2)
-  SOC-WEB1400-Valle-FA25
+  soc-cs3030-valle-su26        (with program, single section)
+  cs3030-valle-su26            (no program)
+  soc-cs3550-2-smith-sp26      (program + section 2)
+  soc-web1400-valle-fa25
 """
 
 import re
 from dataclasses import dataclass
 from typing import Optional
 
-# Regex: SUBJECT-COURSE(-SECTION)?-LASTNAME-SEMESTERYEAR
+# Regex: (program-)?COURSE(-SECTION)?-LAST_NAME-SEMESTERYEAR
 _ORG_NAME_RE = re.compile(
-    r"^(?P<subject>[A-Z]{3,4})"
-    r"-(?P<course>[A-Z]+\d{4})"
+    r"^(?:(?P<program>[a-z]{3,4})-)?"
+    r"(?P<course>[a-z]+\d{4})"
     r"(?:-(?P<section>\d))?"
-    r"-(?P<lastname>[A-Z][a-z]+)"
-    r"-(?P<semester>FA|SP|SU)(?P<year>\d{2})$"
+    r"-(?P<last_name>[a-z][a-z]+)"
+    r"-(?P<semester>fa|sp|su)(?P<year>\d{2})$"
 )
 
-VALID_SEMESTERS = {"FA", "SP", "SU"}
-SEMESTER_LABELS = {"FA": "Fall", "SP": "Spring", "SU": "Summer"}
+VALID_SEMESTERS = {"fa", "sp", "su"}
+SEMESTER_LABELS = {"fa": "Fall", "sp": "Spring", "su": "Summer"}
 
 
 @dataclass
@@ -35,20 +36,20 @@ class ValidationResult:
     Attributes:
         is_valid: Whether the name passes all rules
         error: Human-readable error message (None if valid)
-        subject: Parsed SUBJECT component
-        course: Parsed COURSE component (e.g., CS3030)
+        program: Parsed optional PROGRAM component (e.g., soc, web)
+        course: Parsed COURSE component (e.g., cs3030)
         section: Parsed optional SECTION digit (None if absent)
-        lastname: Parsed LASTNAME component
-        semester: Parsed semester code (FA/SP/SU)
+        last_name: Parsed LAST_NAME component (e.g., valle)
+        semester: Parsed semester code (fa/sp/su)
         year: Parsed 2-digit year string
     """
 
     is_valid: bool
     error: Optional[str] = None
-    subject: Optional[str] = None
+    program: Optional[str] = None
     course: Optional[str] = None
     section: Optional[str] = None
-    lastname: Optional[str] = None
+    last_name: Optional[str] = None
     semester: Optional[str] = None
     year: Optional[str] = None
 
@@ -70,8 +71,8 @@ class ValidationResult:
 class OrgNameValidator:
     """Validates and constructs GitHub organization names per ClassDock convention."""
 
-    FORMAT = "[SUBJECT]-[COURSE][-SECTION]-[LASTNAME]-[SEMESTER][YEAR]"
-    EXAMPLE = "SOC-CS3030-Valle-SU26"
+    FORMAT = "[program-][course][-section]-[last_name]-[semester][year]"
+    EXAMPLE = "soc-cs3030-valle-su26"
 
     @staticmethod
     def validate(name: str) -> ValidationResult:
@@ -99,42 +100,42 @@ class OrgNameValidator:
                     f"'{name}' does not match the required format: {OrgNameValidator.FORMAT}\n"
                     f"  Example: {OrgNameValidator.EXAMPLE}\n"
                     f"  Rules:\n"
-                    f"    SUBJECT  — 3–4 uppercase letters (e.g., SOC, WEB, CS)\n"
-                    f"    COURSE   — uppercase letters + 4-digit number (e.g., CS3030)\n"
-                    f"    SECTION  — optional single digit (e.g., 2)\n"
-                    f"    LASTNAME — capitalized last name (e.g., Valle)\n"
-                    f"    SEMESTER — FA, SP, or SU followed by 2-digit year (e.g., SU26)"
+                    f"    program   — optional 3–4 lowercase letters (e.g., soc, web, cs)\n"
+                    f"    course    — lowercase letters + 4-digit number (e.g., cs3030)\n"
+                    f"    section   — optional single digit (e.g., 2)\n"
+                    f"    last_name — lowercase last name (e.g., valle)\n"
+                    f"    semester  — fa, sp, or su followed by 2-digit year (e.g., su26)"
                 ),
             )
 
         return ValidationResult(
             is_valid=True,
-            subject=m.group("subject"),
+            program=m.group("program"),
             course=m.group("course"),
             section=m.group("section"),
-            lastname=m.group("lastname"),
+            last_name=m.group("last_name"),
             semester=m.group("semester"),
             year=m.group("year"),
         )
 
     @staticmethod
     def build(
-        subject: str,
         course: str,
-        lastname: str,
+        last_name: str,
         semester: str,
         year: str,
+        program: Optional[str] = None,
         section: Optional[str] = None,
     ) -> str:
         """
         Build a compliant organization name from individual components.
 
         Args:
-            subject: 3–4 letter subject prefix (e.g., SOC)
-            course: Course code with number (e.g., CS3030)
-            lastname: Instructor's last name (e.g., Valle)
-            semester: Semester code — FA, SP, or SU
+            course: Course code with number (e.g., cs3030)
+            last_name: Instructor's last name (e.g., valle)
+            semester: Semester code — fa, sp, or su
             year: 2-digit year string (e.g., 26)
+            program: Optional 3–4 letter program prefix (e.g., soc)
             section: Optional single-digit section number
 
         Returns:
@@ -143,16 +144,20 @@ class OrgNameValidator:
         Raises:
             ValueError: If the resulting name fails validation
         """
-        subject = subject.upper().strip()
-        course = course.upper().strip()
-        lastname = lastname.strip().capitalize()
-        semester = semester.upper().strip()
+        if program:
+            program = re.sub(r"[^a-z]", "", program.lower().strip())[:4]
+        course = course.lower().strip()
+        last_name = last_name.lower().strip()
+        semester = semester.lower().strip()
         year = year.strip()
 
-        parts = [subject, course]
+        parts = []
+        if program:
+            parts.append(program)
+        parts.append(course)
         if section:
             parts.append(str(section).strip())
-        parts.append(lastname)
+        parts.append(last_name)
         parts.append(f"{semester}{year}")
 
         name = "-".join(parts)
@@ -165,11 +170,11 @@ class OrgNameValidator:
 
     @staticmethod
     def suggest(
-        subject: str,
         course_number: str,
-        lastname: str,
+        last_name: str,
         semester: str,
         year: str,
+        program: Optional[str] = None,
         section: Optional[str] = None,
     ) -> str:
         """
@@ -178,20 +183,24 @@ class OrgNameValidator:
         Useful for generating a preview before the user finalizes.
         Does not raise on invalid input — returns best-effort string.
         """
-        subject = re.sub(r"[^A-Za-z]", "", subject).upper()[:4]
-        course_number = re.sub(r"[^A-Za-z0-9]", "", course_number).upper()
-        lastname = re.sub(r"[^A-Za-z]", "", lastname).capitalize()
-        semester = semester.upper().strip()
+        if program:
+            program = re.sub(r"[^a-zA-Z]", "", program).lower()[:4]
+        course_number = re.sub(r"[^a-zA-Z0-9]", "", course_number).lower()
+        last_name = re.sub(r"[^a-zA-Z]", "", last_name).lower()
+        semester = semester.lower().strip()
         if semester not in VALID_SEMESTERS:
-            semester = "FA"
+            semester = "fa"
         year = re.sub(r"[^0-9]", "", year)[-2:]
 
-        parts = [subject, course_number]
+        parts = []
+        if program:
+            parts.append(program)
+        parts.append(course_number)
         if section:
             sec = re.sub(r"[^0-9]", "", str(section))
             if sec:
                 parts.append(sec)
-        parts.append(lastname)
+        parts.append(last_name)
         parts.append(f"{semester}{year}")
 
         return "-".join(parts)

--- a/classdock/organizations/validators.py
+++ b/classdock/organizations/validators.py
@@ -85,7 +85,9 @@ class OrgNameValidator:
             ValidationResult with parsed components if valid
         """
         if not name or not name.strip():
-            return ValidationResult(is_valid=False, error="Organization name cannot be empty.")
+            return ValidationResult(
+                is_valid=False, error="Organization name cannot be empty."
+            )
 
         name = name.strip()
 

--- a/classdock/organizations/wizard.py
+++ b/classdock/organizations/wizard.py
@@ -90,10 +90,14 @@ class OrganizationSetupWizard:
         # Step 2b — pick the source GitHub org (filters the repo list)
         source_org = self._step_select_source_org(master_folder)
         if not source_org:
-            return SetupResult(success=False, error_message="No source organization selected.")
+            return SetupResult(
+                success=False, error_message="No source organization selected."
+            )
 
         # Step 3 — select template repos (filtered to source_org only)
-        selected_repos = self._step_select_templates(master_folder, source_org=source_org)
+        selected_repos = self._step_select_templates(
+            master_folder, source_org=source_org
+        )
         if not selected_repos:
             console.print("[yellow]No templates selected. Setup cancelled.[/yellow]")
             return SetupResult(success=False, error_message="No templates selected.")
@@ -101,7 +105,9 @@ class OrganizationSetupWizard:
         # Step 4 — org name
         org_name = self._step_collect_org_name()
         if not org_name:
-            return SetupResult(success=False, error_message="No organization name provided.")
+            return SetupResult(
+                success=False, error_message="No organization name provided."
+            )
 
         # Step 5 — create local folder
         base_dir = master_folder.path.parent
@@ -165,8 +171,14 @@ class OrganizationSetupWizard:
         """Display the organization setup wizard welcome panel."""
         content = Text.assemble(
             ("🏫 ClassDock — New Semester Organization Setup\n\n", "bold magenta"),
-            ("This wizard sets up a GitHub organization and local workspace\n", "white"),
-            ("for a new semester, ready for GitHub Classroom assignments.\n\n", "white"),
+            (
+                "This wizard sets up a GitHub organization and local workspace\n",
+                "white",
+            ),
+            (
+                "for a new semester, ready for GitHub Classroom assignments.\n\n",
+                "white",
+            ),
             ("✨ What this wizard will do:\n", "bold green"),
             ("   • Verify your GitHub token scopes\n", "white"),
             ("   • Detect your master template folder (e.g., CS3030/)\n", "white"),
@@ -264,10 +276,13 @@ class OrganizationSetupWizard:
 
         # Count how many repos each owner has
         from collections import Counter
+
         owner_counts = Counter(r.owner for r in all_repos if r.owner)
 
         if not owner_counts:
-            return typer.prompt("  Enter the source GitHub organization (e.g., cs3030-master)")
+            return typer.prompt(
+                "  Enter the source GitHub organization (e.g., cs3030-master)"
+            )
 
         # Sort by frequency (most common first)
         ranked = owner_counts.most_common()
@@ -275,11 +290,15 @@ class OrganizationSetupWizard:
         if len(ranked) == 1:
             org = ranked[0][0]
             console.print(f"\n  Source GitHub org detected: [cyan]{org}[/cyan]")
-            if typer.confirm(f"  Use '{org}' as the source organization?", default=True):
+            if typer.confirm(
+                f"  Use '{org}' as the source organization?", default=True
+            ):
                 return org
             return typer.prompt("  Enter the source GitHub organization")
 
-        console.print("\n[bold]Source GitHub organizations found in master folder:[/bold]\n")
+        console.print(
+            "\n[bold]Source GitHub organizations found in master folder:[/bold]\n"
+        )
         for i, (owner, count) in enumerate(ranked, start=1):
             console.print(f"  {i}. [cyan]{owner}[/cyan]  ({count} repo(s))")
 
@@ -305,9 +324,7 @@ class OrganizationSetupWizard:
 
         # Filter to the chosen source org
         repos = (
-            [r for r in all_repos if r.owner == source_org]
-            if source_org
-            else all_repos
+            [r for r in all_repos if r.owner == source_org] if source_org else all_repos
         )
 
         if not repos:
@@ -370,16 +387,24 @@ class OrganizationSetupWizard:
 
     def _build_org_name_interactively(self) -> Optional[str]:
         """Prompt for each component individually and build a validated name."""
-        subject = typer.prompt("  SUBJECT (3-4 uppercase letters, e.g., SOC)").strip().upper()
-        course = typer.prompt("  COURSE (letters + 4 digits, e.g., CS3030)").strip().upper()
-        section_raw = typer.prompt("  SECTION (single digit, press Enter to skip)", default="")
+        subject = (
+            typer.prompt("  SUBJECT (3-4 uppercase letters, e.g., SOC)").strip().upper()
+        )
+        course = (
+            typer.prompt("  COURSE (letters + 4 digits, e.g., CS3030)").strip().upper()
+        )
+        section_raw = typer.prompt(
+            "  SECTION (single digit, press Enter to skip)", default=""
+        )
         section = section_raw.strip() or None
         lastname = typer.prompt("  LASTNAME (your last name, e.g., Valle)").strip()
         semester = typer.prompt("  SEMESTER (FA / SP / SU)").strip().upper()
         year = typer.prompt("  YEAR (2-digit, e.g., 26)").strip()
 
         try:
-            name = OrgNameValidator.build(subject, course, lastname, semester, year, section)
+            name = OrgNameValidator.build(
+                subject, course, lastname, semester, year, section
+            )
             console.print(f"\n  Generated name: [green bold]{name}[/green bold]")
             if typer.confirm("  Use this name?", default=True):
                 return name
@@ -393,16 +418,12 @@ class OrganizationSetupWizard:
     ) -> Optional[WorkspaceFolder]:
         """Create the local semester org folder."""
         if self.dry_run:
-            console.print(
-                f"[dry-run] Would create folder: {base / org_name}"
-            )
+            console.print(f"[dry-run] Would create folder: {base / org_name}")
             return WorkspaceFolder(path=base / org_name, org_name=org_name)
 
         existing = self._workspace_manager.find_org_folder(base, org_name)
         if existing:
-            console.print(
-                f"  [yellow]Folder already exists: {existing.path}[/yellow]"
-            )
+            console.print(f"  [yellow]Folder already exists: {existing.path}[/yellow]")
             if not typer.confirm("  Continue using existing folder?", default=True):
                 return None
             return existing
@@ -473,26 +494,30 @@ class OrganizationSetupWizard:
             console.print(
                 "Once you have created the organization manually, press Enter to continue."
             )
-            typer.prompt("  Press Enter when the org is ready", default="", show_default=False)
+            typer.prompt(
+                "  Press Enter when the org is ready", default="", show_default=False
+            )
             # Verify the org now exists
             if self._org_manager.organization_exists(org_name):
                 print_success(f"Organization '{org_name}' confirmed on GitHub.")
                 return self._org_manager.get_organization(org_name)
             else:
-                print_error(f"Organization '{org_name}' not found. Continuing without GitHub org.")
+                print_error(
+                    f"Organization '{org_name}' not found. Continuing without GitHub org."
+                )
                 return None
         except PermissionError as exc:
             print_error(str(exc))
             return None
         except Exception as exc:
             print_error(f"Organization creation failed: {exc}")
-            if typer.confirm("  Continue setup without creating the org?", default=True):
+            if typer.confirm(
+                "  Continue setup without creating the org?", default=True
+            ):
                 return None
             raise
 
-    def _step_fork_to_github(
-        self, target_org: str, repos: List[TemplateRepo]
-    ):
+    def _step_fork_to_github(self, target_org: str, repos: List[TemplateRepo]):
         """
         Fork selected repos to the new GitHub org.
 
@@ -522,13 +547,16 @@ class OrganizationSetupWizard:
                 target_org=target_org,
             )
             if forked is None:
-                error_msg = f"Failed to copy '{repo.owner}/{repo.name}' into '{target_org}'"
+                error_msg = (
+                    f"Failed to copy '{repo.owner}/{repo.name}' into '{target_org}'"
+                )
                 result.add_failure(error_msg)
                 console.print(f"    [red]✗ {error_msg}[/red]")
                 continue
 
             # Brief pause then mark as template
             import time
+
             time.sleep(3)
             ok = self._template_manager.make_template(target_org, forked.name)
             forked.is_template = ok
@@ -540,7 +568,9 @@ class OrganizationSetupWizard:
             for err in result.errors:
                 console.print(f"    • {err}")
 
-        print_success(f"Forked {result.successful}/{result.total} repo(s) to '{target_org}'")
+        print_success(
+            f"Forked {result.successful}/{result.total} repo(s) to '{target_org}'"
+        )
         return result
 
     def _step_classroom_guidance(
@@ -568,7 +598,8 @@ class OrganizationSetupWizard:
                         f"[bold]{source_org}[/bold]."
                     )
                     clone_it = typer.confirm(
-                        "Generate assignment checklist from this classroom?", default=True
+                        "Generate assignment checklist from this classroom?",
+                        default=True,
                     )
                     if clone_it:
                         source_classroom_id = sc.id

--- a/classdock/organizations/wizard.py
+++ b/classdock/organizations/wizard.py
@@ -25,14 +25,9 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-
 from rich.text import Text
 
-from ..utils.ui_components import (
-    print_error,
-    print_status,
-    print_success,
-)
+from ..utils.ui_components import print_error, print_status, print_success
 from .classroom import ClassroomManager
 from .manager import OrganizationManager
 from .models import Organization, SetupResult, TemplateRepo, WorkspaceFolder

--- a/classdock/organizations/wizard.py
+++ b/classdock/organizations/wizard.py
@@ -185,7 +185,7 @@ class OrganizationSetupWizard:
             ("   • Fork templates into the new org as GitHub templates\n\n", "white"),
             ("📋 You'll need:\n", "bold blue"),
             ("   • A master template folder with cloned assignment repos\n", "white"),
-            ("   • New organization name (e.g., SOC-CS3030-Valle-SU26)\n", "white"),
+            ("   • New organization name (e.g., soc-cs3030-valle-su26)\n", "white"),
             ("   • GitHub token with repo + admin:org scopes\n", "white"),
             ("   • A billing email for the new organization\n", "white"),
         )
@@ -362,8 +362,8 @@ class OrganizationSetupWizard:
         """Prompt for and validate the new GitHub organization name."""
         console.print(
             "\n[bold]Organization Naming Convention:[/bold]\n"
-            "  [SUBJECT]-[COURSE][-SECTION]-[LASTNAME]-[SEMESTER][YEAR]\n"
-            "  Example: SOC-CS3030-Valle-SU26\n"
+            "  [program-][course][-section]-[last_name]-[semester][year]\n"
+            "  Example: soc-cs3030-valle-su26\n"
         )
 
         # Offer component-by-component guidance
@@ -382,23 +382,26 @@ class OrganizationSetupWizard:
 
     def _build_org_name_interactively(self) -> Optional[str]:
         """Prompt for each component individually and build a validated name."""
-        subject = (
-            typer.prompt("  SUBJECT (3-4 uppercase letters, e.g., SOC)").strip().upper()
+        program_raw = typer.prompt(
+            "  PROGRAM (3-4 letters, e.g., soc — press Enter to skip)", default=""
         )
+        program = program_raw.strip().lower() or None
         course = (
-            typer.prompt("  COURSE (letters + 4 digits, e.g., CS3030)").strip().upper()
+            typer.prompt("  COURSE (letters + 4 digits, e.g., cs3030)").strip().lower()
         )
         section_raw = typer.prompt(
             "  SECTION (single digit, press Enter to skip)", default=""
         )
         section = section_raw.strip() or None
-        lastname = typer.prompt("  LASTNAME (your last name, e.g., Valle)").strip()
-        semester = typer.prompt("  SEMESTER (FA / SP / SU)").strip().upper()
+        last_name = (
+            typer.prompt("  LAST NAME (your last name, e.g., valle)").strip().lower()
+        )
+        semester = typer.prompt("  SEMESTER (fa / sp / su)").strip().lower()
         year = typer.prompt("  YEAR (2-digit, e.g., 26)").strip()
 
         try:
             name = OrgNameValidator.build(
-                subject, course, lastname, semester, year, section
+                course, last_name, semester, year, program, section
             )
             console.print(f"\n  Generated name: [green bold]{name}[/green bold]")
             if typer.confirm("  Use this name?", default=True):

--- a/classdock/organizations/workspace.py
+++ b/classdock/organizations/workspace.py
@@ -8,7 +8,7 @@ The ClassDock workspace follows this convention:
     │   ├── .classdock-master               ← marker identifying master folder
     │   ├── python-basics/                   ← local git clone of template repo
     │   └── midterm-project/
-    └── SOC-CS3030-Valle-SU26/              ← semester org folder
+    └── soc-cs3030-valle-su26/              ← semester org folder
         ├── .classdock-org                  ← marker with org name
         ├── assignment.conf                  ← generated classdock config
         ├── python-basics/                   ← cloned from master

--- a/classdock/organizations/workspace.py
+++ b/classdock/organizations/workspace.py
@@ -48,7 +48,9 @@ class WorkspaceManager:
     # Master folder operations
     # ------------------------------------------------------------------
 
-    def find_master_folder(self, start: Optional[Path] = None) -> Optional[WorkspaceFolder]:
+    def find_master_folder(
+        self, start: Optional[Path] = None
+    ) -> Optional[WorkspaceFolder]:
         """
         Search for the nearest master template folder above the given path.
 

--- a/classdock/utils/github_api_client.py
+++ b/classdock/utils/github_api_client.py
@@ -609,9 +609,7 @@ class GitHubAPIClient:
                 timeout=60,
             )
             if response.status_code in (202, 200):
-                logger.info(
-                    "Forked '%s/%s' into '%s'", owner, repo, target_org
-                )
+                logger.info("Forked '%s/%s' into '%s'", owner, repo, target_org)
                 return response.json()
             logger.error(
                 "Fork failed for '%s/%s' → '%s': HTTP %s %s",
@@ -678,7 +676,10 @@ class GitHubAPIClient:
             if response.status_code in (201, 200):
                 logger.info(
                     "Created '%s/%s' from template '%s/%s'",
-                    target_owner, new_name, template_owner, template_repo,
+                    target_owner,
+                    new_name,
+                    template_owner,
+                    template_repo,
                 )
                 return response.json()
             if response.status_code == 422:
@@ -686,7 +687,9 @@ class GitHubAPIClient:
                 if "already exists" in body.lower():
                     logger.debug(
                         "'%s/%s' already exists in '%s'; skipping.",
-                        target_owner, new_name, target_owner,
+                        target_owner,
+                        new_name,
+                        target_owner,
                     )
                     raise RepoAlreadyExistsError(
                         f"'{target_owner}/{new_name}' already exists",
@@ -695,8 +698,10 @@ class GitHubAPIClient:
                     )
             logger.error(
                 "create_from_template failed for '%s/%s' → '%s/%s': HTTP %s %s",
-                template_owner, template_repo,
-                target_owner, new_name,
+                template_owner,
+                template_repo,
+                target_owner,
+                new_name,
                 response.status_code,
                 response.text[:300],
             )
@@ -706,7 +711,11 @@ class GitHubAPIClient:
         except Exception as exc:
             logger.error(
                 "Error creating '%s/%s' from template '%s/%s': %s",
-                target_owner, new_name, template_owner, template_repo, exc,
+                target_owner,
+                new_name,
+                template_owner,
+                template_repo,
+                exc,
             )
             return None
 
@@ -734,9 +743,7 @@ class GitHubAPIClient:
                 timeout=30,
             )
             if response.status_code == 200:
-                logger.info(
-                    "Set is_template=%s on '%s/%s'", is_template, owner, repo
-                )
+                logger.info("Set is_template=%s on '%s/%s'", is_template, owner, repo)
                 return True
             logger.error(
                 "Failed to set is_template on '%s/%s': HTTP %s %s",
@@ -747,9 +754,7 @@ class GitHubAPIClient:
             )
             return False
         except Exception as exc:
-            logger.error(
-                "Error setting template flag on '%s/%s': %s", owner, repo, exc
-            )
+            logger.error("Error setting template flag on '%s/%s': %s", owner, repo, exc)
             return False
 
     def _get_assignment_template_repo(self, assignment_id: int) -> str:

--- a/classdock/utils/github_graphql_client.py
+++ b/classdock/utils/github_graphql_client.py
@@ -117,7 +117,9 @@ class GitHubGraphQLClient:
         try:
             response = self._session.post(GRAPHQL_ENDPOINT, json=payload, timeout=30)
         except requests.exceptions.ConnectionError as exc:
-            raise GitHubAPIError(f"Network error connecting to GitHub GraphQL: {exc}") from exc
+            raise GitHubAPIError(
+                f"Network error connecting to GitHub GraphQL: {exc}"
+            ) from exc
         except requests.exceptions.Timeout as exc:
             raise GitHubAPIError("GitHub GraphQL request timed out.") from exc
 
@@ -233,5 +235,7 @@ class GitHubGraphQLClient:
         data = self.execute(_VIEWER_SCOPES_QUERY)
         login = data.get("viewer", {}).get("login", "")
         if not login:
-            raise GitHubAPIError("Could not determine authenticated user's GitHub login.")
+            raise GitHubAPIError(
+                "Could not determine authenticated user's GitHub login."
+            )
         return login

--- a/classdock/utils/github_graphql_client.py
+++ b/classdock/utils/github_graphql_client.py
@@ -163,7 +163,7 @@ class GitHubGraphQLClient:
         Create a new GitHub organization.
 
         Args:
-            login: The organization login/slug (e.g., SOC-CS3030-Valle-SU26)
+            login: The organization login/slug (e.g., soc-cs3030-valle-su26)
             billing_email: Billing contact email for the organization
             admin_login: GitHub username to add as admin. Defaults to the
                          authenticated user's login (fetched automatically).

--- a/classdock/utils/paths.py
+++ b/classdock/utils/paths.py
@@ -165,7 +165,9 @@ class PathManager:
                 return current
             current = current.parent
 
-        logger.debug("No master template folder found (no %s marker)", self._MASTER_MARKER)
+        logger.debug(
+            "No master template folder found (no %s marker)", self._MASTER_MARKER
+        )
         return None
 
     def get_org_folder(self, base: Path, org_name: str) -> Path:

--- a/classdock/utils/paths.py
+++ b/classdock/utils/paths.py
@@ -176,7 +176,7 @@ class PathManager:
 
         Args:
             base: Base directory that contains all course/org folders.
-            org_name: GitHub organization name (e.g., SOC-CS3030-Valle-SU26).
+            org_name: GitHub organization name (e.g., soc-cs3030-valle-su26).
 
         Returns:
             Path pointing to ``<base>/<org_name>``.

--- a/docs/ORGANIZATION_SETUP.md
+++ b/docs/ORGANIZATION_SETUP.md
@@ -15,7 +15,7 @@ and each semester creates a new **semester org folder** linked to a GitHub organ
 │   ├── python-basics/                   # local git clone of template repo
 │   ├── midterm-project/
 │   └── final-project/
-└── SOC-CS3030-Valle-SU26/              # semester org folder (one per semester)
+└── soc-cs3030-valle-su26/              # semester org folder (one per semester)
     ├── .classdock-org                  # marker file (contains org name)
     ├── assignment.conf                  # generated ClassDock configuration
     ├── python-basics/                   # cloned from master
@@ -30,21 +30,22 @@ and each semester creates a new **semester org folder** linked to a GitHub organ
 GitHub organizations must follow this format:
 
 ```
-[SUBJECT]-[COURSE][-SECTION]-[LASTNAME]-[SEMESTER][YEAR]
+[program-][course][-section]-[last_name]-[semester][year]
 ```
 
 | Component | Rules | Example |
 |-----------|-------|---------|
-| SUBJECT | 3–4 uppercase letters | `SOC`, `WEB`, `CYBR` |
-| COURSE | Uppercase letters + 4-digit number | `CS3030`, `WEB1400` |
-| SECTION | Optional single digit | `2` (omit if only one section) |
-| LASTNAME | Capitalized last name | `Valle`, `Smith` |
-| SEMESTER | `FA` / `SP` / `SU` + 2-digit year | `SU26`, `FA25` |
+| program | Optional 3–4 lowercase letters | `soc`, `web`, `cybr` |
+| course | Lowercase letters + 4-digit number | `cs3030`, `web1400` |
+| section | Optional single digit | `2` (omit if only one section) |
+| last_name | Lowercase last name | `valle`, `smith` |
+| semester | `fa` / `sp` / `su` + 2-digit year | `su26`, `fa25` |
 
 **Valid examples:**
-- `SOC-CS3030-Valle-SU26` (single section)
-- `SOC-CS3550-2-Smith-SP26` (section 2)
-- `SOC-WEB1400-Valle-FA25`
+- `soc-cs3030-valle-su26` (with program, single section)
+- `cs3030-valle-su26` (no program)
+- `soc-cs3550-2-smith-sp26` (program + section 2)
+- `soc-web1400-valle-fa25`
 
 ---
 
@@ -105,19 +106,19 @@ Accepting generates:
 **Option B — No source classroom found (manual guidance)**
 
 1. Go to [classroom.github.com/classrooms/new](https://classroom.github.com/classrooms/new)
-2. Select your new organization (e.g., `SOC-CS3030-Valle-SU26`)
+2. Select your new organization (e.g., `soc-cs3030-valle-su26`)
 3. Name your classroom (e.g., "CS3030 Summer 2026")
 4. Create assignments using the template repos now in your org
 
 You can also generate a checklist later:
 ```bash
-classdock organizations classroom clone <SOURCE_CLASSROOM_ID> SOC-CS3030-Valle-SU26
+classdock organizations classroom clone <SOURCE_CLASSROOM_ID> soc-cs3030-valle-su26
 ```
 
 ### Step 4 — Configure and Run Assignments
 
 ```bash
-cd ~/courses/SOC-CS3030-Valle-SU26
+cd ~/courses/soc-cs3030-valle-su26
 classdock assignments setup    # configure the first assignment
 classdock assignments orchestrate  # run the full workflow
 ```
@@ -137,7 +138,7 @@ classdock organizations init --dry-run   # preview without making changes
 
 ```bash
 classdock organizations create \
-    --login SOC-CS3030-Valle-SU26 \
+    --login soc-cs3030-valle-su26 \
     --email instructor@weber.edu \
     --name "CS3030 Summer 2026"
 ```
@@ -150,12 +151,12 @@ Requires the `admin:org` scope on your GitHub token.
 # Clone all template repos from a source org
 classdock organizations clone-templates \
     --source-org CS3030-master \
-    --target-org SOC-CS3030-Valle-SU26
+    --target-org soc-cs3030-valle-su26
 
 # Clone specific repos only
 classdock organizations clone-templates \
     --source-org CS3030-master \
-    --target-org SOC-CS3030-Valle-SU26 \
+    --target-org soc-cs3030-valle-su26 \
     --repos python-basics \
     --repos midterm-project
 ```
@@ -163,7 +164,7 @@ classdock organizations clone-templates \
 The output is a per-repo status table:
 
 ```
-     Clone: CS3030-master → SOC-CS3030-Valle-SU26
+     Clone: CS3030-master → soc-cs3030-valle-su26
 ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Repository        ┃  Status  ┃
 ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
@@ -189,7 +190,7 @@ classdock organizations list
 ### Verify an Organization
 
 ```bash
-classdock organizations verify SOC-CS3030-Valle-SU26
+classdock organizations verify soc-cs3030-valle-su26
 ```
 
 Displays org details, total repo count, template repo count, and a per-repo table.
@@ -209,7 +210,7 @@ generates deep-link creation URLs.
 classdock organizations classroom list
 
 # Filtered to a specific organization
-classdock organizations classroom list SOC-CS3030-Valle-SU26
+classdock organizations classroom list soc-cs3030-valle-su26
 ```
 
 Output includes classroom name, linked organization, archived status, and URL.
@@ -221,15 +222,15 @@ Output includes classroom name, linked organization, archived status, and URL.
 classdock organizations classroom assignments
 
 # Filtered by org (fewer choices in the first menu)
-classdock organizations classroom assignments SOC-CS3030-Valle-SU26
+classdock organizations classroom assignments soc-cs3030-valle-su26
 ```
 
 The command presents three interactive menus in sequence:
 
 ```
-Classrooms in 'SOC-CS3030-Valle-SU26':
+Classrooms in 'soc-cs3030-valle-su26':
 
-  1. CS3030-Valle-SU26-classroom  (SOC-CS3030-Valle-SU26)
+  1. CS3030-Valle-SU26-classroom  (soc-cs3030-valle-su26)
 
 Select classroom [1-1] [1]:
 
@@ -251,7 +252,7 @@ Select assignment to view student repos [1-2] [1]:
 
 ```bash
 classdock organizations classroom grades
-classdock organizations classroom grades SOC-CS3030-Valle-SU26
+classdock organizations classroom grades soc-cs3030-valle-su26
 ```
 
 Same org → classroom → assignment selection flow, then displays:
@@ -268,11 +269,11 @@ Same org → classroom → assignment selection flow, then displays:
 
 ```bash
 # Get source classroom ID from: classdock organizations classroom list
-classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26
+classdock organizations classroom clone 298811 soc-cs3030-valle-fa26
 
 # Write classroom_setup.md to a specific workspace folder
-classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26 \
-    --workspace ~/courses/SOC-CS3030-Valle-FA26
+classdock organizations classroom clone 298811 soc-cs3030-valle-fa26 \
+    --workspace ~/courses/soc-cs3030-valle-fa26
 ```
 
 This command:
@@ -283,7 +284,7 @@ This command:
 
 Example output:
 ```
-    Assignment Checklist: CS3030-S26-classroom → SOC-CS3030-Valle-FA26
+    Assignment Checklist: CS3030-S26-classroom → soc-cs3030-valle-fa26
 ┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Assignment    ┃ Type       ┃ Deadline   ┃ Starter  ┃ Create URL               ┃
 ┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
@@ -333,15 +334,15 @@ classdock organizations init
 #      clone locally, create GitHub org, fork templates, generate checklist
 
 # 2. Verify the new org and its repos
-classdock organizations verify SOC-CS3030-Valle-FA26
+classdock organizations verify soc-cs3030-valle-fa26
 
 # 3. (If wizard found a source classroom) Follow the generated checklist
-#    classroom_setup.md is written to ~/courses/SOC-CS3030-Valle-FA26/
+#    classroom_setup.md is written to ~/courses/soc-cs3030-valle-fa26/
 
 # 4. (If no source classroom) Clone structure from a previous semester's classroom
 classdock organizations classroom list                  # find the source classroom ID
-classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26 \
-    --workspace ~/courses/SOC-CS3030-Valle-FA26
+classdock organizations classroom clone 298811 soc-cs3030-valle-fa26 \
+    --workspace ~/courses/soc-cs3030-valle-fa26
 
 # 5. Create the GitHub Classroom manually (API limitation)
 #    → Visit classroom.github.com/classrooms/new, select the new org
@@ -350,11 +351,11 @@ classdock organizations classroom clone 298811 SOC-CS3030-Valle-FA26 \
 # ── MID-SEMESTER MONITORING ───────────────────────────────────────────
 
 # Check student submission progress for any assignment
-classdock organizations classroom assignments SOC-CS3030-Valle-FA26
+classdock organizations classroom assignments soc-cs3030-valle-fa26
 #    → Select classroom → select assignment → student repos table
 
 # Review grades
-classdock organizations classroom grades SOC-CS3030-Valle-FA26
+classdock organizations classroom grades soc-cs3030-valle-fa26
 #    → Select classroom → select assignment → grades table
 
 # ── REPEAT NEXT SEMESTER ──────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "classdock"
-version = "0.4.0"
+version = "0.4.1"
 description = "Modern Python CLI for automating GitHub Classroom assignment management"
 authors = [
     {name = "Hugo Valle", email = "hugovalle1@weber.edu"}

--- a/tests/test_organization_classroom.py
+++ b/tests/test_organization_classroom.py
@@ -22,7 +22,7 @@ _CLASSROOM_DICT = {
     "name": "CS3030 Summer 2026",
     "url": "https://classroom.github.com/classrooms/100",
     "archived": False,
-    "organization": {"login": "SOC-CS3030-Valle-SU26"},
+    "organization": {"login": "soc-cs3030-valle-su26"},
 }
 
 _ASSIGNMENT_DICT = {
@@ -62,7 +62,7 @@ class TestClassroomModel:
         c = Classroom.from_dict(_CLASSROOM_DICT)
         assert c.id == 100
         assert c.name == "CS3030 Summer 2026"
-        assert c.org_login == "SOC-CS3030-Valle-SU26"
+        assert c.org_login == "soc-cs3030-valle-su26"
         assert c.archived is False
 
     def test_from_dict_archived(self):
@@ -79,7 +79,7 @@ class TestClassroomModel:
         c = Classroom.from_dict(_CLASSROOM_DICT)
         d = c.to_dict()
         assert d["id"] == 100
-        assert d["org_login"] == "SOC-CS3030-Valle-SU26"
+        assert d["org_login"] == "soc-cs3030-valle-su26"
 
 
 class TestClassroomAssignmentModel:
@@ -146,9 +146,9 @@ class TestListClassroomsForOrg:
             _CLASSROOM_DICT,
             {**_CLASSROOM_DICT, "id": 200, "organization": {"login": "other-org"}},
         ]
-        classrooms = manager.list_classrooms_for_org("SOC-CS3030-Valle-SU26")
+        classrooms = manager.list_classrooms_for_org("soc-cs3030-valle-su26")
         assert len(classrooms) == 1
-        assert classrooms[0].org_login == "SOC-CS3030-Valle-SU26"
+        assert classrooms[0].org_login == "soc-cs3030-valle-su26"
 
     def test_case_insensitive(self, manager):
         manager._api.get_classrooms_paginated.return_value = [_CLASSROOM_DICT]

--- a/tests/test_organization_manager.py
+++ b/tests/test_organization_manager.py
@@ -47,12 +47,12 @@ class TestListUserOrganizations:
 class TestGetOrganization:
     def test_returns_organization(self, manager):
         manager._rest.get_organization.return_value = {
-            "login": "SOC-CS3030-Valle-SU26",
+            "login": "soc-cs3030-valle-su26",
             "id": 99,
         }
-        org = manager.get_organization("SOC-CS3030-Valle-SU26")
+        org = manager.get_organization("soc-cs3030-valle-su26")
         assert org is not None
-        assert org.login == "SOC-CS3030-Valle-SU26"
+        assert org.login == "soc-cs3030-valle-su26"
 
     def test_returns_none_when_not_found(self, manager):
         manager._rest.get_organization.return_value = None
@@ -76,31 +76,31 @@ class TestCreateOrganization:
         manager._graphql.get_token_scopes.return_value = ["repo"]
         with pytest.raises(PermissionError, match="admin:org"):
             manager.create_organization(
-                "SOC-CS3030-Valle-SU26", "instructor@example.com"
+                "soc-cs3030-valle-su26", "instructor@example.com"
             )
 
     def test_creates_org_when_scope_present(self, manager):
         manager._graphql.has_scope.return_value = True
         manager._graphql.create_organization.return_value = {
-            "login": "SOC-CS3030-Valle-SU26",
+            "login": "soc-cs3030-valle-su26",
             "name": "CS3030 Summer 2026",
-            "url": "https://github.com/SOC-CS3030-Valle-SU26",
+            "url": "https://github.com/soc-cs3030-valle-su26",
         }
         org = manager.create_organization(
-            "SOC-CS3030-Valle-SU26", "instructor@example.com", display_name="CS3030"
+            "soc-cs3030-valle-su26", "instructor@example.com", display_name="CS3030"
         )
-        assert org.login == "SOC-CS3030-Valle-SU26"
+        assert org.login == "soc-cs3030-valle-su26"
         assert org.name == "CS3030"
 
     def test_uses_login_as_name_fallback(self, manager):
         manager._graphql.has_scope.return_value = True
         manager._graphql.create_organization.return_value = {
-            "login": "SOC-CS3030-Valle-SU26",
+            "login": "soc-cs3030-valle-su26",
         }
         org = manager.create_organization(
-            "SOC-CS3030-Valle-SU26", "instructor@example.com"
+            "soc-cs3030-valle-su26", "instructor@example.com"
         )
-        assert org.name == "SOC-CS3030-Valle-SU26"
+        assert org.name == "soc-cs3030-valle-su26"
 
 
 class TestTokenHelpers:

--- a/tests/test_organization_models.py
+++ b/tests/test_organization_models.py
@@ -21,32 +21,32 @@ class TestOrganization:
     """Tests for Organization model."""
 
     def test_create_minimal(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26")
-        assert org.login == "SOC-CS3030-Valle-SU26"
+        org = Organization(login="soc-cs3030-valle-su26")
+        assert org.login == "soc-cs3030-valle-su26"
         assert org.id is None
         assert org.name is None
 
     def test_from_dict(self):
         data = {
-            "login": "SOC-CS3030-Valle-SU26",
+            "login": "soc-cs3030-valle-su26",
             "name": "CS3030 Summer 2026",
             "id": 42,
             "description": "Test org",
-            "html_url": "https://github.com/SOC-CS3030-Valle-SU26",
+            "html_url": "https://github.com/soc-cs3030-valle-su26",
             "avatar_url": "https://example.com/avatar.png",
             "role": "admin",
         }
         org = Organization.from_dict(data)
-        assert org.login == "SOC-CS3030-Valle-SU26"
+        assert org.login == "soc-cs3030-valle-su26"
         assert org.name == "CS3030 Summer 2026"
         assert org.id == 42
         assert org.role == "admin"
         assert "github.com" in org.url
 
     def test_to_dict_roundtrip(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26", name="CS3030", id=1, role="admin")
+        org = Organization(login="soc-cs3030-valle-su26", name="CS3030", id=1, role="admin")
         d = org.to_dict()
-        assert d["login"] == "SOC-CS3030-Valle-SU26"
+        assert d["login"] == "soc-cs3030-valle-su26"
         assert d["name"] == "CS3030"
         assert d["id"] == 1
 
@@ -55,8 +55,8 @@ class TestTemplateRepo:
     """Tests for TemplateRepo model."""
 
     def test_create_minimal(self):
-        repo = TemplateRepo(name="python-basics", owner="SOC-CS3030-Valle-SU26")
-        assert repo.full_name == "SOC-CS3030-Valle-SU26/python-basics"
+        repo = TemplateRepo(name="python-basics", owner="soc-cs3030-valle-su26")
+        assert repo.full_name == "soc-cs3030-valle-su26/python-basics"
         assert not repo.is_template
 
     def test_full_name_auto_populated(self):
@@ -70,17 +70,17 @@ class TestTemplateRepo:
     def test_from_dict(self):
         data = {
             "name": "python-basics",
-            "owner": {"login": "SOC-CS3030-Valle-SU26"},
-            "full_name": "SOC-CS3030-Valle-SU26/python-basics",
-            "html_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics",
-            "clone_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics.git",
+            "owner": {"login": "soc-cs3030-valle-su26"},
+            "full_name": "soc-cs3030-valle-su26/python-basics",
+            "html_url": "https://github.com/soc-cs3030-valle-su26/python-basics",
+            "clone_url": "https://github.com/soc-cs3030-valle-su26/python-basics.git",
             "is_template": True,
             "private": False,
             "description": "Python basics assignment",
         }
         repo = TemplateRepo.from_dict(data)
         assert repo.name == "python-basics"
-        assert repo.owner == "SOC-CS3030-Valle-SU26"
+        assert repo.owner == "soc-cs3030-valle-su26"
         assert repo.is_template is True
 
     def test_to_dict(self):
@@ -168,7 +168,7 @@ class TestSetupResult:
         assert r.organization is None
 
     def test_with_all_fields(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26")
+        org = Organization(login="soc-cs3030-valle-su26")
         r = SetupResult(organization=org, success=True)
         assert r.success
-        assert r.organization.login == "SOC-CS3030-Valle-SU26"
+        assert r.organization.login == "soc-cs3030-valle-su26"

--- a/tests/test_organization_paths.py
+++ b/tests/test_organization_paths.py
@@ -51,12 +51,12 @@ class TestGetOrgFolder:
 
     def test_returns_correct_path(self, tmp_path):
         pm = PathManager(tmp_path)
-        result = pm.get_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
-        assert result == tmp_path / "SOC-CS3030-Valle-SU26"
+        result = pm.get_org_folder(tmp_path, "soc-cs3030-valle-su26")
+        assert result == tmp_path / "soc-cs3030-valle-su26"
 
     def test_does_not_create_directory(self, tmp_path):
         pm = PathManager(tmp_path)
-        result = pm.get_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        result = pm.get_org_folder(tmp_path, "soc-cs3030-valle-su26")
         assert not result.exists()
 
 
@@ -65,29 +65,29 @@ class TestEnsureOrgFolder:
 
     def test_creates_directory(self, tmp_path):
         pm = PathManager(tmp_path)
-        result = pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        result = pm.ensure_org_folder(tmp_path, "soc-cs3030-valle-su26")
         assert result.is_dir()
 
     def test_creates_marker_file(self, tmp_path):
         pm = PathManager(tmp_path)
-        result = pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        result = pm.ensure_org_folder(tmp_path, "soc-cs3030-valle-su26")
         marker = result / ".classdock-org"
         assert marker.exists()
-        assert marker.read_text(encoding="utf-8") == "SOC-CS3030-Valle-SU26"
+        assert marker.read_text(encoding="utf-8") == "soc-cs3030-valle-su26"
 
     def test_folder_name_matches_org_name(self, tmp_path):
         pm = PathManager(tmp_path)
-        result = pm.ensure_org_folder(tmp_path, "SOC-CS3550-2-Smith-SP26")
-        assert result.name == "SOC-CS3550-2-Smith-SP26"
+        result = pm.ensure_org_folder(tmp_path, "soc-cs3550-2-smith-sp26")
+        assert result.name == "soc-cs3550-2-smith-sp26"
 
     def test_idempotent_when_called_twice(self, tmp_path):
         pm = PathManager(tmp_path)
-        pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
-        result = pm.ensure_org_folder(tmp_path, "SOC-CS3030-Valle-SU26")
+        pm.ensure_org_folder(tmp_path, "soc-cs3030-valle-su26")
+        result = pm.ensure_org_folder(tmp_path, "soc-cs3030-valle-su26")
         assert result.is_dir()
 
     def test_creates_nested_base(self, tmp_path):
         nested_base = tmp_path / "courses" / "2026"
         pm = PathManager(tmp_path)
-        result = pm.ensure_org_folder(nested_base, "SOC-CS3030-Valle-SU26")
+        result = pm.ensure_org_folder(nested_base, "soc-cs3030-valle-su26")
         assert result.is_dir()

--- a/tests/test_organization_service.py
+++ b/tests/test_organization_service.py
@@ -35,12 +35,12 @@ def _make_service(wizard_result=None, dry_run=False):
 
 class TestSetup:
     def test_returns_true_on_success(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26")
+        org = Organization(login="soc-cs3030-valle-su26")
         result = SetupResult(success=True, organization=org)
         svc = _make_service(wizard_result=result)
         ok, msg = svc.setup()
         assert ok
-        assert "SOC-CS3030-Valle-SU26" in msg
+        assert "soc-cs3030-valle-su26" in msg
 
     def test_returns_false_on_failure(self):
         result = SetupResult(success=False, error_message="No master folder selected.")
@@ -80,9 +80,9 @@ class TestListOrganizations:
 class TestVerifyOrganization:
     def test_returns_true_and_org_when_exists(self):
         svc = _make_service()
-        org = Organization(login="SOC-CS3030-Valle-SU26")
+        org = Organization(login="soc-cs3030-valle-su26")
         svc._org_manager.get_organization.return_value = org
-        exists, found = svc.verify_organization("SOC-CS3030-Valle-SU26")
+        exists, found = svc.verify_organization("soc-cs3030-valle-su26")
         assert exists
         assert found == org
 

--- a/tests/test_organization_templates.py
+++ b/tests/test_organization_templates.py
@@ -22,10 +22,10 @@ def manager():
 
 _REPO_DICT = {
     "name": "python-basics",
-    "owner": {"login": "SOC-CS3030-Valle-SU26"},
-    "full_name": "SOC-CS3030-Valle-SU26/python-basics",
-    "html_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics",
-    "clone_url": "https://github.com/SOC-CS3030-Valle-SU26/python-basics.git",
+    "owner": {"login": "soc-cs3030-valle-su26"},
+    "full_name": "soc-cs3030-valle-su26/python-basics",
+    "html_url": "https://github.com/soc-cs3030-valle-su26/python-basics",
+    "clone_url": "https://github.com/soc-cs3030-valle-su26/python-basics.git",
     "is_template": True,
     "private": False,
     "description": "Python basics assignment",
@@ -35,7 +35,7 @@ _REPO_DICT = {
 class TestListOrgTemplates:
     def test_returns_template_repos(self, manager):
         manager._api.list_org_repos.return_value = [_REPO_DICT]
-        repos = manager.list_org_templates("SOC-CS3030-Valle-SU26")
+        repos = manager.list_org_templates("soc-cs3030-valle-su26")
         assert len(repos) == 1
         assert isinstance(repos[0], TemplateRepo)
 
@@ -58,7 +58,7 @@ class TestForkRepository:
         repo = manager.fork_repository(
             source_owner="master-org",
             repo_name="python-basics",
-            target_org="SOC-CS3030-Valle-SU26",
+            target_org="soc-cs3030-valle-su26",
         )
         assert repo is not None
         assert repo.name == "python-basics"
@@ -98,7 +98,7 @@ class TestCloneTemplates:
         self._setup_success(manager)
         result = manager.clone_templates(
             source_org="CS3030",
-            target_org="SOC-CS3030-Valle-SU26",
+            target_org="soc-cs3030-valle-su26",
             repo_names=["python-basics", "midterm-project"],
             settle_seconds=0,
         )
@@ -122,7 +122,7 @@ class TestCloneTemplates:
 
         result = manager.clone_templates(
             source_org="CS3030",
-            target_org="SOC-CS3030-Valle-SU26",
+            target_org="soc-cs3030-valle-su26",
             repo_names=["fail-repo", "ok-repo"],
             settle_seconds=0,
         )

--- a/tests/test_organization_validators.py
+++ b/tests/test_organization_validators.py
@@ -7,9 +7,9 @@ Covers OrgNameValidator.validate(), .build(), and .suggest().
 import pytest
 
 from classdock.organizations.validators import (
+    VALID_SEMESTERS,
     OrgNameValidator,
     ValidationResult,
-    VALID_SEMESTERS,
 )
 
 
@@ -19,39 +19,51 @@ class TestValidate:
     # --- valid names ---
 
     def test_valid_no_section(self):
-        result = OrgNameValidator.validate("SOC-CS3030-Valle-SU26")
+        result = OrgNameValidator.validate("soc-cs3030-valle-su26")
         assert result.is_valid
         assert result.error is None
-        assert result.subject == "SOC"
-        assert result.course == "CS3030"
+        assert result.program == "soc"
+        assert result.course == "cs3030"
         assert result.section is None
-        assert result.lastname == "Valle"
-        assert result.semester == "SU"
+        assert result.last_name == "valle"
+        assert result.semester == "su"
         assert result.year == "26"
 
     def test_valid_with_section(self):
-        result = OrgNameValidator.validate("SOC-CS3550-2-Smith-SP26")
+        result = OrgNameValidator.validate("soc-cs3550-2-smith-sp26")
         assert result.is_valid
         assert result.section == "2"
-        assert result.lastname == "Smith"
-        assert result.semester == "SP"
+        assert result.last_name == "smith"
+        assert result.semester == "sp"
 
     def test_valid_fall_semester(self):
-        result = OrgNameValidator.validate("SOC-WEB1400-Valle-FA25")
+        result = OrgNameValidator.validate("soc-web1400-valle-fa25")
         assert result.is_valid
-        assert result.semester == "FA"
-        assert result.course == "WEB1400"
+        assert result.semester == "fa"
+        assert result.course == "web1400"
 
-    def test_valid_four_letter_subject(self):
-        # CYBR is a 4-letter subject (CYBER has 5, which exceeds the 3-4 letter rule)
-        result = OrgNameValidator.validate("CYBR-CS2700-Jones-FA25")
+    def test_valid_four_letter_program(self):
+        result = OrgNameValidator.validate("cybr-cs2700-jones-fa25")
         assert result.is_valid
-        assert result.subject == "CYBR"
+        assert result.program == "cybr"
 
     def test_valid_section_1(self):
-        result = OrgNameValidator.validate("SOC-CS2810-1-Brown-SP26")
+        result = OrgNameValidator.validate("soc-cs2810-1-brown-sp26")
         assert result.is_valid
         assert result.section == "1"
+
+    def test_valid_without_program(self):
+        result = OrgNameValidator.validate("cs3030-valle-su26")
+        assert result.is_valid
+        assert result.program is None
+        assert result.course == "cs3030"
+        assert result.last_name == "valle"
+
+    def test_valid_without_program_with_section(self):
+        result = OrgNameValidator.validate("cs3550-2-smith-sp26")
+        assert result.is_valid
+        assert result.program is None
+        assert result.section == "2"
 
     # --- invalid names ---
 
@@ -64,41 +76,42 @@ class TestValidate:
         result = OrgNameValidator.validate("   ")
         assert not result.is_valid
 
-    def test_lowercase_subject(self):
-        result = OrgNameValidator.validate("soc-CS3030-Valle-SU26")
+    def test_uppercase_org_name_invalid(self):
+        result = OrgNameValidator.validate("SOC-CS3030-VALLE-SU26")
         assert not result.is_valid
 
     def test_invalid_semester(self):
-        result = OrgNameValidator.validate("SOC-CS3030-Valle-WI26")
+        result = OrgNameValidator.validate("soc-cs3030-valle-wi26")
         assert not result.is_valid
 
-    def test_lowercase_lastname(self):
-        result = OrgNameValidator.validate("SOC-CS3030-valle-SU26")
+    def test_uppercase_lastname_invalid(self):
+        result = OrgNameValidator.validate("soc-cs3030-VALLE-su26")
         assert not result.is_valid
 
     def test_missing_year(self):
-        result = OrgNameValidator.validate("SOC-CS3030-Valle-SU")
+        result = OrgNameValidator.validate("soc-cs3030-valle-su")
         assert not result.is_valid
 
     def test_three_digit_course(self):
-        result = OrgNameValidator.validate("SOC-CS303-Valle-SU26")
+        result = OrgNameValidator.validate("soc-cs303-valle-su26")
         assert not result.is_valid
 
     def test_no_dashes(self):
-        result = OrgNameValidator.validate("SOCCS3030ValleSU26")
+        result = OrgNameValidator.validate("soccs3030vallesu26")
         assert not result.is_valid
 
     def test_extra_segment(self):
-        # Too many parts that don't match pattern
-        result = OrgNameValidator.validate("SOC-CS3030-Valle-SU26-EXTRA")
+        result = OrgNameValidator.validate("soc-cs3030-valle-su26-extra")
         assert not result.is_valid
 
-    def test_subject_too_long(self):
-        result = OrgNameValidator.validate("SOCIA-CS3030-Valle-SU26")
+    def test_program_too_long(self):
+        # 5-letter program prefix is invalid
+        result = OrgNameValidator.validate("socia-cs3030-valle-su26")
         assert not result.is_valid
 
-    def test_subject_too_short(self):
-        result = OrgNameValidator.validate("SO-CS3030-Valle-SU26")
+    def test_program_too_short(self):
+        # 2-letter program prefix is invalid
+        result = OrgNameValidator.validate("so-cs3030-valle-su26")
         assert not result.is_valid
 
 
@@ -106,19 +119,19 @@ class TestValidationResultProperties:
     """Tests for ValidationResult helper properties."""
 
     def test_semester_label_fall(self):
-        r = OrgNameValidator.validate("SOC-CS3030-Valle-FA25")
+        r = OrgNameValidator.validate("soc-cs3030-valle-fa25")
         assert r.semester_label == "Fall"
 
     def test_semester_label_spring(self):
-        r = OrgNameValidator.validate("SOC-CS3030-Valle-SP26")
+        r = OrgNameValidator.validate("soc-cs3030-valle-sp26")
         assert r.semester_label == "Spring"
 
     def test_semester_label_summer(self):
-        r = OrgNameValidator.validate("SOC-CS3030-Valle-SU26")
+        r = OrgNameValidator.validate("soc-cs3030-valle-su26")
         assert r.semester_label == "Summer"
 
     def test_full_year(self):
-        r = OrgNameValidator.validate("SOC-CS3030-Valle-FA25")
+        r = OrgNameValidator.validate("soc-cs3030-valle-fa25")
         assert r.full_year == "2025"
 
     def test_semester_label_none_when_invalid(self):
@@ -131,42 +144,62 @@ class TestBuild:
     """Tests for OrgNameValidator.build()."""
 
     def test_build_no_section(self):
-        name = OrgNameValidator.build("SOC", "CS3030", "Valle", "SU", "26")
-        assert name == "SOC-CS3030-Valle-SU26"
+        name = OrgNameValidator.build("cs3030", "valle", "su", "26", program="soc")
+        assert name == "soc-cs3030-valle-su26"
 
     def test_build_with_section(self):
-        name = OrgNameValidator.build("SOC", "CS3550", "Smith", "SP", "26", section="2")
-        assert name == "SOC-CS3550-2-Smith-SP26"
+        name = OrgNameValidator.build(
+            "cs3550", "smith", "sp", "26", program="soc", section="2"
+        )
+        assert name == "soc-cs3550-2-smith-sp26"
 
-    def test_build_normalizes_case(self):
-        name = OrgNameValidator.build("soc", "cs3030", "valle", "su", "26")
-        assert name == "SOC-CS3030-Valle-SU26"
+    def test_build_without_program(self):
+        name = OrgNameValidator.build("cs3030", "valle", "su", "26")
+        assert name == "cs3030-valle-su26"
+
+    def test_build_normalizes_to_lowercase(self):
+        name = OrgNameValidator.build("CS3030", "VALLE", "SU", "26", program="SOC")
+        assert name == "soc-cs3030-valle-su26"
 
     def test_build_invalid_raises(self):
         with pytest.raises(ValueError, match="invalid"):
-            OrgNameValidator.build("SO", "CS3030", "Valle", "SU", "26")  # subject too short
+            # Single-letter last name is invalid (regex requires [a-z][a-z]+)
+            OrgNameValidator.build("cs3030", "v", "su", "26")
+
+    def test_valid_semesters_are_lowercase(self):
+        assert VALID_SEMESTERS == {"fa", "sp", "su"}
 
 
 class TestSuggest:
     """Tests for OrgNameValidator.suggest()."""
 
     def test_suggest_basic(self):
-        name = OrgNameValidator.suggest("SOC", "CS3030", "Valle", "SU", "26")
-        assert name == "SOC-CS3030-Valle-SU26"
+        name = OrgNameValidator.suggest("cs3030", "valle", "su", "26", program="soc")
+        assert name == "soc-cs3030-valle-su26"
 
     def test_suggest_with_section(self):
-        name = OrgNameValidator.suggest("SOC", "CS3550", "Smith", "SP", "26", section="2")
-        assert name == "SOC-CS3550-2-Smith-SP26"
+        name = OrgNameValidator.suggest(
+            "cs3550", "smith", "sp", "26", program="soc", section="2"
+        )
+        assert name == "soc-cs3550-2-smith-sp26"
 
-    def test_suggest_normalizes_lowercase_input(self):
-        name = OrgNameValidator.suggest("soc", "cs3030", "valle", "su", "26")
-        assert name == "SOC-CS3030-Valle-SU26"
+    def test_suggest_without_program(self):
+        name = OrgNameValidator.suggest("cs3030", "valle", "su", "26")
+        assert name == "cs3030-valle-su26"
+
+    def test_suggest_normalizes_to_lowercase(self):
+        name = OrgNameValidator.suggest("CS3030", "VALLE", "SU", "26", program="SOC")
+        assert name == "soc-cs3030-valle-su26"
 
     def test_suggest_invalid_semester_defaults_to_fa(self):
-        name = OrgNameValidator.suggest("SOC", "CS3030", "Valle", "WINTER", "26")
-        assert "FA" in name
+        name = OrgNameValidator.suggest(
+            "cs3030", "valle", "winter", "26", program="soc"
+        )
+        assert "fa" in name
 
     def test_suggest_strips_special_chars(self):
-        name = OrgNameValidator.suggest("S O C!", "CS 3030", "Val-le", "SU", "26")
-        assert "SOC" in name
-        assert "CS3030" in name
+        name = OrgNameValidator.suggest(
+            "cs 3030", "val-le", "su", "26", program="s o c!"
+        )
+        assert "soc" in name
+        assert "cs3030" in name

--- a/tests/test_organization_workspace.py
+++ b/tests/test_organization_workspace.py
@@ -110,18 +110,18 @@ class TestInitMasterFolder:
 
 class TestCreateOrgFolder:
     def test_creates_directory(self, tmp_workspace, manager):
-        wf = manager.create_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
-        assert (tmp_workspace / "SOC-CS3030-Valle-SU26").is_dir()
+        wf = manager.create_org_folder(tmp_workspace, "soc-cs3030-valle-su26")
+        assert (tmp_workspace / "soc-cs3030-valle-su26").is_dir()
 
     def test_creates_marker_file(self, tmp_workspace, manager):
-        wf = manager.create_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        wf = manager.create_org_folder(tmp_workspace, "soc-cs3030-valle-su26")
         marker = wf.path / ".classdock-org"
         assert marker.exists()
 
     def test_returns_workspace_folder(self, tmp_workspace, manager):
-        wf = manager.create_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        wf = manager.create_org_folder(tmp_workspace, "soc-cs3030-valle-su26")
         assert not wf.is_master
-        assert wf.org_name == "SOC-CS3030-Valle-SU26"
+        assert wf.org_name == "soc-cs3030-valle-su26"
 
 
 class TestFindOrgFolder:
@@ -129,10 +129,10 @@ class TestFindOrgFolder:
         assert manager.find_org_folder(tmp_workspace, "nonexistent-org") is None
 
     def test_returns_folder_when_exists(self, tmp_workspace, manager):
-        (tmp_workspace / "SOC-CS3030-Valle-SU26").mkdir()
-        wf = manager.find_org_folder(tmp_workspace, "SOC-CS3030-Valle-SU26")
+        (tmp_workspace / "soc-cs3030-valle-su26").mkdir()
+        wf = manager.find_org_folder(tmp_workspace, "soc-cs3030-valle-su26")
         assert wf is not None
-        assert wf.org_name == "SOC-CS3030-Valle-SU26"
+        assert wf.org_name == "soc-cs3030-valle-su26"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_organizations_cli.py
+++ b/tests/test_organizations_cli.py
@@ -39,14 +39,14 @@ class TestOrgList:
         assert "No organizations found" in result.output
 
     def test_shows_org_table(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26", name="CS3030", role="admin")
+        org = Organization(login="soc-cs3030-valle-su26", name="CS3030", role="admin")
         with patch(
             "classdock.commands.organizations.OrganizationManager",
             _mock_org_manager(orgs=[org]),
         ):
             result = runner.invoke(app, ["organizations", "list"])
         assert result.exit_code == 0
-        assert "SOC-CS3030-Valle-SU26" in result.output
+        assert "soc-cs3030-valle-su26" in result.output
 
 
 def _mock_template_manager(repos=None):
@@ -56,45 +56,45 @@ def _mock_template_manager(repos=None):
 
 
 _SAMPLE_REPOS = [
-    TemplateRepo(name="python-basics", owner="SOC-CS3030-Valle-SU26", is_template=True),
-    TemplateRepo(name="midterm-project", owner="SOC-CS3030-Valle-SU26", is_template=False),
+    TemplateRepo(name="python-basics", owner="soc-cs3030-valle-su26", is_template=True),
+    TemplateRepo(name="midterm-project", owner="soc-cs3030-valle-su26", is_template=False),
 ]
 
 
 class TestOrgVerify:
     def test_valid_org_found(self):
         org = Organization(
-            login="SOC-CS3030-Valle-SU26",
+            login="soc-cs3030-valle-su26",
             name="CS3030 SU26",
-            url="https://github.com/SOC-CS3030-Valle-SU26",
+            url="https://github.com/soc-cs3030-valle-su26",
             role="admin",
         )
         with (
             patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
             patch("classdock.commands.organizations.TemplateManager", _mock_template_manager(_SAMPLE_REPOS)),
         ):
-            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+            result = runner.invoke(app, ["organizations", "verify", "soc-cs3030-valle-su26"])
         assert result.exit_code == 0
         assert "verified" in result.output.lower()
 
     def test_shows_repo_count(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26")
+        org = Organization(login="soc-cs3030-valle-su26")
         with (
             patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
             patch("classdock.commands.organizations.TemplateManager", _mock_template_manager(_SAMPLE_REPOS)),
         ):
-            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+            result = runner.invoke(app, ["organizations", "verify", "soc-cs3030-valle-su26"])
         assert result.exit_code == 0
         assert "2" in result.output   # total repos
         assert "1" in result.output   # template repos
 
     def test_shows_repo_names(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26")
+        org = Organization(login="soc-cs3030-valle-su26")
         with (
             patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
             patch("classdock.commands.organizations.TemplateManager", _mock_template_manager(_SAMPLE_REPOS)),
         ):
-            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+            result = runner.invoke(app, ["organizations", "verify", "soc-cs3030-valle-su26"])
         assert "python-basics" in result.output
         assert "midterm-project" in result.output
 
@@ -115,12 +115,12 @@ class TestOrgVerify:
         assert "Warning" in result.output or result.exit_code in (0, 1)
 
     def test_no_repos_shows_empty(self):
-        org = Organization(login="SOC-CS3030-Valle-SU26")
+        org = Organization(login="soc-cs3030-valle-su26")
         with (
             patch("classdock.commands.organizations.OrganizationManager", _mock_org_manager(org=org)),
             patch("classdock.commands.organizations.TemplateManager", _mock_template_manager([])),
         ):
-            result = runner.invoke(app, ["organizations", "verify", "SOC-CS3030-Valle-SU26"])
+            result = runner.invoke(app, ["organizations", "verify", "soc-cs3030-valle-su26"])
         assert result.exit_code == 0
         assert "0" in result.output
 
@@ -142,7 +142,7 @@ class TestOrgCreate:
                     "organizations",
                     "create",
                     "--login",
-                    "SOC-CS3030-Valle-SU26",
+                    "soc-cs3030-valle-su26",
                     "--email",
                     "a@b.com",
                 ],
@@ -164,7 +164,7 @@ class TestOrgCreate:
                     "organizations",
                     "create",
                     "--login",
-                    "SOC-CS3030-Valle-SU26",
+                    "soc-cs3030-valle-su26",
                     "--email",
                     "a@b.com",
                 ],
@@ -192,7 +192,7 @@ class TestOrgCloneTemplates:
                     "--source-org",
                     "CS3030",
                     "--target-org",
-                    "SOC-CS3030-Valle-SU26",
+                    "soc-cs3030-valle-su26",
                     "--repos",
                     "python-basics",
                 ],
@@ -217,7 +217,7 @@ class TestOrgCloneTemplates:
                     "--source-org",
                     "CS3030",
                     "--target-org",
-                    "SOC-CS3030-Valle-SU26",
+                    "soc-cs3030-valle-su26",
                 ],
             )
         assert result.exit_code == 1
@@ -240,7 +240,7 @@ class TestOrgCloneTemplates:
                     "--source-org",
                     "CS3030",
                     "--target-org",
-                    "SOC-CS3030-Valle-SU26",
+                    "soc-cs3030-valle-su26",
                 ],
             )
         assert result.exit_code == 0
@@ -263,7 +263,7 @@ class TestOrgCloneTemplates:
                     "--source-org",
                     "CS3030",
                     "--target-org",
-                    "SOC-CS3030-Valle-SU26",
+                    "soc-cs3030-valle-su26",
                 ],
             )
         assert "No repositories" in result.output


### PR DESCRIPTION
## Release v0.4.1

### What's new

**feat(organizations): lowercase org names with optional program prefix**
- New naming format: `[program?-][course][section?]-[last_name]-[semester][year]`
- Examples: `cs6610-valle-su26`, `soc-cs3030-valle-fa26`
- Program prefix is now optional (was previously required)
- Everything lowercase — no more Shift key required
- Closes #114

**chore(ci): upgrade GitHub Actions to Node.js 24 (v5)**
- All GitHub-owned actions updated: `checkout`, `cache`, `upload-artifact`, `download-artifact` → `@v5`
- `setup-python` fixed `@v4` → `@v5` in `security-audit.yml`
- `codecov-action` `@v4` → `@v5`
- Fixed `secrets manage` → `secrets add` in `performance.yml`

## Test plan

- [ ] All CI checks pass
- [ ] `classdock organizations init` wizard shows new lowercase format
- [ ] `classdock organizations verify cs6610-valle-su26` validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)